### PR TITLE
templates: layer term aliases + loader for ui-initialized-templates

### DIFF
--- a/apps/ui/src/components/shell/AppSidebar.vue
+++ b/apps/ui/src/components/shell/AppSidebar.vue
@@ -20,7 +20,7 @@ import { RouterLink, useRoute, useRouter } from 'vue-router';
 import Icon, { type IconName } from '@/components/icons/Icon.vue';
 import logoSw from '@/assets/icons/logo-sw.svg?raw';
 import { useAuthStore } from '@/stores/auth';
-import { LAYERS } from './layers';
+import { LAYERS, hasTopology } from './layers';
 
 const auth = useAuthStore();
 const router = useRouter();
@@ -174,12 +174,20 @@ const sections: NavSection[] = [
           </RouterLink>
 
           <RouterLink
-            v-if="L.caps.topology"
+            v-if="hasTopology(L.caps)"
             :to="`/layer/${L.key}/topology`"
             class="sw-nav-item"
             :class="{ 'is-active': isActive(`/layer/${L.key}/topology`) }"
           >
             <Icon name="topo" /><span>Topology</span>
+          </RouterLink>
+          <RouterLink
+            v-if="L.caps.endpointDependency"
+            :to="`/layer/${L.key}/dependency`"
+            class="sw-nav-item"
+            :class="{ 'is-active': isActive(`/layer/${L.key}/dependency`) }"
+          >
+            <Icon name="ep" /><span>{{ L.slots.endpointDependency ?? `${L.slots.endpoints ?? 'Endpoint'} dependency` }}</span>
           </RouterLink>
           <RouterLink
             v-if="L.caps.dashboards"

--- a/apps/ui/src/components/shell/layers.ts
+++ b/apps/ui/src/components/shell/layers.ts
@@ -18,21 +18,43 @@
 // Phase 2 will replace this static stub with real getMenuItems / listLayers
 // data + per-layer overrides from the BFF dashboard-template bundle. The
 // shape is what the sidebar and router will consume regardless.
+//
+// Aliases (`slots.*`) are a GLOBAL term presenter — the same alias is used
+// in the sidebar, breadcrumbs, table headers, dashboard titles, drill-down
+// labels, etc. "Endpoint" → "API" (General), "API → API" (the resulting
+// endpoint-relation feature) → "API dependency".
+//
+// `caps` is a pickable feature set per layer. Setting `caps.services =
+// false` hides the services slot entirely (e.g. a layer with only a single
+// virtual service can disable `instances` and `endpoints` but keep
+// `services`).
+//
+// Term aliases AND cap toggles are both editable from the Phase 7 admin UI
+// (Layer config) and persisted in the BFF JSON store. The values below are
+// the shipped defaults for each known layer.
 
 export interface LayerSlots {
-  /** Renamed service-equivalent (functions / workloads / clusters / apps / databases / …). */
+  /** Renamed service-equivalent (functions / workloads / clusters / apps / databases / virtual service / …). */
   services?: string;
   /** Renamed instance-equivalent (versions / pods / brokers / sessions / nodes / …). */
   instances?: string;
-  /** Renamed endpoint-equivalent (invocations / topics / pages / queries / …). */
+  /** Renamed endpoint-equivalent — e.g. "API" for General, "Topics" for MQ, "Pages" for Browser. */
   endpoints?: string;
+  /** Label for the endpoint-to-endpoint dependency feature. Defaults to `${endpoints} dependency`. */
+  endpointDependency?: string;
 }
 
 export interface LayerCaps {
   /** Per-layer landing page with KPIs / constellation / health. */
   overview?: boolean;
-  /** Topology graph. */
-  topology?: boolean;
+  /** Service map (service topology). */
+  serviceMap?: boolean;
+  /** Endpoint-to-endpoint dependency (a.k.a. "API dependency" when aliased). */
+  endpointDependency?: boolean;
+  /** Instance / pod / broker topology. */
+  instanceTopology?: boolean;
+  /** Process topology (eBPF / rover sourced). */
+  processTopology?: boolean;
   /** Per-scope dashboards (Service / Instance / Endpoint / Glance). */
   dashboards?: boolean;
   /** Trace explorer (SkyWalking native or Zipkin sources). */
@@ -43,6 +65,11 @@ export interface LayerCaps {
   profiling?: boolean;
   /** Event timeline. */
   events?: boolean;
+}
+
+/** Convenience: `caps.serviceMap || caps.instanceTopology || caps.processTopology`. */
+export function hasTopology(caps: LayerCaps): boolean {
+  return Boolean(caps.serviceMap || caps.instanceTopology || caps.processTopology);
 }
 
 export interface LayerDef {
@@ -62,8 +89,19 @@ export const LAYERS: readonly LayerDef[] = [
     name: 'General Service',
     color: 'var(--sw-accent)',
     serviceCount: 84,
-    slots: { services: 'Services', instances: 'Instances', endpoints: 'Endpoints' },
-    caps: { overview: true, topology: true, dashboards: true, traces: true, logs: true, profiling: true, events: true },
+    slots: { services: 'Services', instances: 'Instances', endpoints: 'API', endpointDependency: 'API dependency' },
+    caps: {
+      overview: true,
+      serviceMap: true,
+      endpointDependency: true,
+      instanceTopology: true,
+      processTopology: true,
+      dashboards: true,
+      traces: true,
+      logs: true,
+      profiling: true,
+      events: true,
+    },
   },
   {
     key: 'mesh',
@@ -71,7 +109,16 @@ export const LAYERS: readonly LayerDef[] = [
     color: 'var(--sw-info)',
     serviceCount: 22,
     slots: { services: 'Services', instances: 'Sidecars', endpoints: 'Endpoints' },
-    caps: { overview: true, topology: true, dashboards: true, traces: true, logs: true, events: true },
+    caps: {
+      overview: true,
+      serviceMap: true,
+      endpointDependency: true,
+      instanceTopology: true,
+      dashboards: true,
+      traces: true,
+      logs: true,
+      events: true,
+    },
   },
   {
     key: 'k8s',
@@ -79,7 +126,7 @@ export const LAYERS: readonly LayerDef[] = [
     color: 'var(--sw-purple)',
     serviceCount: 62,
     slots: { services: 'Workloads', instances: 'Pods' },
-    caps: { overview: true, topology: true, dashboards: true, events: true },
+    caps: { overview: true, serviceMap: true, instanceTopology: true, dashboards: true, events: true },
   },
   {
     key: 'rum',
@@ -111,7 +158,14 @@ export const LAYERS: readonly LayerDef[] = [
     color: 'var(--sw-purple)',
     serviceCount: 18,
     slots: { services: 'Services', instances: 'Instances', endpoints: 'Endpoints' },
-    caps: { overview: true, topology: true, dashboards: true, traces: true, logs: true },
+    caps: {
+      overview: true,
+      serviceMap: true,
+      endpointDependency: true,
+      dashboards: true,
+      traces: true,
+      logs: true,
+    },
   },
   {
     key: 'faas',

--- a/apps/ui/src/router/index.ts
+++ b/apps/ui/src/router/index.ts
@@ -56,24 +56,31 @@ function layerSubRoutes(): RouteRecordRaw[] {
     });
   }
 
-  const caps: { key: keyof NonNullable<ReturnType<typeof findLayer>>['caps']; label: string; phase: string }[] = [
-    { key: 'topology', label: 'Topology', phase: 'Phase 4' },
-    { key: 'dashboards', label: 'Dashboards', phase: 'Phase 3' },
-    { key: 'traces', label: 'Traces', phase: 'Phase 5' },
-    { key: 'logs', label: 'Logs', phase: 'Phase 5' },
-    { key: 'profiling', label: 'Profiling', phase: 'Phase 8' },
-    { key: 'events', label: 'Events', phase: 'Phase 5' },
+  const layerFeatures: { path: string; label: string; phase: string; capCheck?: (caps: NonNullable<ReturnType<typeof findLayer>>['caps']) => boolean }[] = [
+    {
+      path: 'topology',
+      label: 'Topology',
+      phase: 'Phase 4',
+      capCheck: (c) => Boolean(c.serviceMap || c.instanceTopology || c.processTopology),
+    },
+    { path: 'dependency', label: 'API dependency', phase: 'Phase 4', capCheck: (c) => Boolean(c.endpointDependency) },
+    { path: 'dashboards', label: 'Dashboards', phase: 'Phase 3', capCheck: (c) => Boolean(c.dashboards) },
+    { path: 'traces', label: 'Traces', phase: 'Phase 5', capCheck: (c) => Boolean(c.traces) },
+    { path: 'logs', label: 'Logs', phase: 'Phase 5', capCheck: (c) => Boolean(c.logs) },
+    { path: 'profiling', label: 'Profiling', phase: 'Phase 8', capCheck: (c) => Boolean(c.profiling) },
+    { path: 'events', label: 'Events', phase: 'Phase 5', capCheck: (c) => Boolean(c.events) },
   ];
-  for (const c of caps) {
+  for (const f of layerFeatures) {
     sub.push({
-      path: `layer/:layerKey/${c.key}`,
+      path: `layer/:layerKey/${f.path}`,
       component: placeholder,
       props: (r) => {
         const L = findLayer(String(r.params.layerKey));
+        const supported = L && (!f.capCheck || f.capCheck(L.caps));
         return {
-          title: L ? `${L.name} · ${c.label}` : `Layer · ${c.label}`,
-          phase: c.phase,
-          note: L && !L.caps[c.key] ? `${L.name} doesn't expose ${c.label.toLowerCase()}.` : undefined,
+          title: L ? `${L.name} · ${f.label}` : `Layer · ${f.label}`,
+          phase: f.phase,
+          note: L && !supported ? `${L.name} doesn't expose ${f.label.toLowerCase()}.` : undefined,
         };
       },
     });

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -14,6 +14,7 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^22.9.0",
     "typescript": "~5.6.3"
   }
 }

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -15,5 +15,12 @@
  * limitations under the License.
  */
 
-// Phase 2 will populate this with the ui-initialized-templates bundle.
-export {};
+export * from './types.js';
+export {
+  loadAll,
+  listLayers,
+  listTemplates,
+  getTemplate,
+  getMenuYaml,
+  templateCount,
+} from './loader.js';

--- a/packages/templates/src/loader.ts
+++ b/packages/templates/src/loader.ts
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Lazy Node loader for the bundled `ui-initialized-templates` tree.
+ *
+ * Reads each layer subdirectory under `./data/`, parses the single-element
+ * outer array OAP loader expects, returns flat `DashboardConfiguration`
+ * records. `menu.yaml` is left as a raw string for the BFF to parse (we
+ * don't pull a YAML dep into this leaf package).
+ *
+ * All public functions are pure — callers can memoize freely.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { DashboardConfiguration } from './types.js';
+
+const dataDir = join(dirname(fileURLToPath(import.meta.url)), 'data');
+
+let _cache: DashboardConfiguration[] | null = null;
+let _menuYamlCache: string | null = null;
+
+function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function parseTemplate(absPath: string): DashboardConfiguration | null {
+  let raw: string;
+  try {
+    raw = readFileSync(absPath, 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // The upstream `custom/placeholder.json` uses JSON comments which the
+    // OAP loader allows via Jackson but standard JSON.parse rejects. We
+    // stripped it at copy time, but tolerate similar drift here.
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null;
+  const first = parsed[0] as { id?: string; configuration?: unknown };
+  const cfg = first?.configuration;
+  if (!cfg || typeof cfg !== 'object') return null;
+  const dc = cfg as DashboardConfiguration;
+  // Promote the wrapper `id` into the configuration so callers can identify
+  // the template by id without re-reading the outer array.
+  if (first.id && dc.id === undefined) dc.id = first.id;
+  return dc;
+}
+
+/** Load and cache every template in the bundle. */
+export function loadAll(): readonly DashboardConfiguration[] {
+  if (_cache) return _cache;
+  const out: DashboardConfiguration[] = [];
+  for (const entry of readdirSync(dataDir)) {
+    const layerPath = join(dataDir, entry);
+    if (!isDir(layerPath)) continue;
+    for (const f of readdirSync(layerPath)) {
+      if (!f.endsWith('.json')) continue;
+      const t = parseTemplate(join(layerPath, f));
+      if (t) out.push(t);
+    }
+  }
+  _cache = out;
+  return out;
+}
+
+/** Distinct layer values that have at least one template. */
+export function listLayers(): string[] {
+  const set = new Set<string>();
+  for (const t of loadAll()) set.add(t.layer);
+  return [...set].sort();
+}
+
+/** Templates filtered by layer (case-sensitive against the on-disk value). */
+export function listTemplates(layer?: string): DashboardConfiguration[] {
+  const all = loadAll();
+  return layer ? all.filter((t) => t.layer === layer) : [...all];
+}
+
+/** Return the dashboard configuration matching the OAP de-dupe key `(layer, entity, name)`. */
+export function getTemplate(
+  layer: string,
+  entity: string,
+  name: string,
+): DashboardConfiguration | undefined {
+  return loadAll().find((t) => t.layer === layer && t.entity === entity && t.name === name);
+}
+
+/** Raw `menu.yaml` content. The BFF parses it. */
+export function getMenuYaml(): string {
+  if (_menuYamlCache !== null) return _menuYamlCache;
+  const text = readFileSync(join(dataDir, 'menu.yaml'), 'utf8');
+  _menuYamlCache = text;
+  return text;
+}
+
+/** Total template count — useful for tests + boot logging. */
+export function templateCount(): number {
+  return loadAll().length;
+}

--- a/packages/templates/src/types.ts
+++ b/packages/templates/src/types.ts
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Wire types for SkyWalking dashboard templates.
+ *
+ * Field-compatible with booster-ui's `LayoutConfig` so existing exports
+ * round-trip without massage. New fields are additive; we never rename a
+ * key that booster-ui or the OAP loader writes.
+ *
+ * Reference shape (from `oap-server/.../UITemplateInitializer.java`):
+ *   `[{ id, configuration: { children, layer, entity, name, isRoot, ... } }]`
+ * The outer single-element array is a Jackson loader artifact; we strip
+ * it on read so consumers see `DashboardConfiguration` directly.
+ */
+
+/** Per-expression display options on a widget. */
+export interface MetricConfigOpt {
+  unit?: string;
+  label?: string;
+  labelsIndex?: string;
+  sortOrder?: string;
+  topN?: number;
+  index?: number;
+  detailLabel?: string;
+}
+
+/** Per-widget chart-style options. The literal `type` discriminates the union. */
+export type GraphConfig =
+  | { type: 'Line' | 'Area' | 'Bar' | 'Card' | 'Table' | 'TopList' | 'HeatMap'; [k: string]: unknown }
+  | { type: 'ServiceList' | 'InstanceList' | 'EndpointList'; dashboardName?: string; [k: string]: unknown }
+  | { type: 'Topology'; [k: string]: unknown }
+  | { type: 'Text' | 'TimeRange'; [k: string]: unknown }
+  | { type: string; [k: string]: unknown };
+
+/** A widget node inside a dashboard configuration. */
+export interface LayoutConfig {
+  /** vue-grid-layout coords. */
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+  /** Stable widget id (string, sometimes a tab-prefixed compound like `"4-0-10"`). */
+  i?: string;
+
+  /** Widget type enum. See `views/dashboard/data.ts` in booster-ui. */
+  type: string;
+
+  /** MQE expressions evaluated for this widget. Always plural. */
+  expressions?: string[];
+  subExpressions?: string[];
+  typesOfMQE?: string[];
+
+  metricConfig?: MetricConfigOpt[];
+
+  widget?: {
+    name?: string;
+    title?: string;
+    tips?: string;
+    url?: string;
+    type?: string;
+  };
+
+  graph?: GraphConfig;
+
+  /**
+   * For `Tab` widgets each child is a tab pane (`{name, children}`).
+   * For everything else each child is a nested widget.
+   */
+  children?: (LayoutTab | LayoutConfig)[];
+
+  associate?: Array<{ widgetId: string }>;
+  relatedTrace?: {
+    refIdType?: string;
+    enableRelate?: boolean;
+    latency?: boolean;
+    status?: string;
+    duration?: number;
+    queryOrder?: string;
+  };
+
+  /** Drill-down dashboard names. */
+  valueRelatedDashboard?: string;
+  linkDashboard?: string;
+  nodeDashboard?: Array<{ scope: string; dashboard: string }>;
+  instanceDashboardName?: string;
+  processDashboardName?: string;
+
+  /** Topology-specific MQE bundles. */
+  linkServerExpressions?: string[];
+  linkClientExpressions?: string[];
+  nodeExpressions?: string[];
+
+  legendMQE?: { expression: string };
+
+  filters?: unknown;
+  auto?: boolean;
+  autoPeriod?: number;
+
+  /** Forward-compat escape hatch. Avoid relying on this in new code. */
+  [key: string]: unknown;
+}
+
+export interface LayoutTab {
+  name: string;
+  children: LayoutConfig[];
+  expression?: string;
+  enable?: boolean;
+}
+
+/** Top-level dashboard configuration parsed from a template JSON file. */
+export interface DashboardConfiguration {
+  /** Source-of-truth identifier (e.g. `"General-Service"`). */
+  id?: string;
+  layer: string;
+  entity: string;
+  name: string;
+  /** Landing dashboard for `(layer, entity)` when true. */
+  isRoot?: boolean;
+  /** Hierarchy default for `entity = Service` chains. */
+  isDefault?: boolean;
+  /** Optional URL fragment hint; rare. */
+  path?: string;
+  /** Top-level expressions (used by hierarchy widgets). */
+  expressions?: string[];
+  expressionsConfig?: MetricConfigOpt[];
+  /** Widget tree. */
+  children: LayoutConfig[];
+}
+
+/**
+ * Menu item shape from OAP's `getMenuItems` query / our local `menu.yaml`
+ * mirror. Identical wire shape so the BFF can substitute one for the other.
+ */
+export interface MenuItem {
+  title: string;
+  icon?: string;
+  layer: string;
+  /** Computed server-side from "layer has services?". */
+  activate?: boolean;
+  subItems?: MenuItem[];
+  description?: string;
+  documentLink?: string;
+  i18nKey?: string;
+}

--- a/packages/templates/tsconfig.json
+++ b/packages/templates/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
**Stacked on PR #1.** Depends on the CI fix + templates data import.

### What lands

`packages/templates`:
- `types.ts` — `DashboardConfiguration`, `LayoutConfig`, `LayoutTab`, `MetricConfigOpt`, `GraphConfig`, `MenuItem` (field-compatible with booster-ui's shape).
- `loader.ts` — lazy Node loader: `loadAll()`, `listLayers()`, `listTemplates(layer?)`, `getTemplate(layer, entity, name)`, `getMenuYaml()`, `templateCount()`. Strips the outer single-element array OAP's loader wraps each file in.
- `@types/node` added; tsconfig wires it in.

`apps/ui`:
- `layers.ts`: per-layer **term aliases** (`slots.services / instances / endpoints / endpointDependency`) — a global term presenter. General Service ships with `endpoint: 'API'`, `endpointDependency: 'API dependency'`. Plus an expanded **cap picker** — `serviceMap`, `endpointDependency`, `instanceTopology`, `processTopology`, `dashboards`, `traces`, `logs`, `profiling`, `events`.
- `AppSidebar.vue`: renders the "API dependency" row when `caps.endpointDependency` is on; `hasTopology()` collapses the topology link when no topology variant is enabled.
- `router/index.ts`: per-feature stub routes reflect cap availability; layers without the cap show a 'doesn't expose' note instead of pretending.

### Verified

`pnpm -r run type-check` clean across all 5 workspaces.