### PR TITLE
fix(admin): unpublished-edits prompt re-shows after login + align verb gates

### DIFF
--- a/apps/ui/src/shell/TemplateConflictPrompt.vue
+++ b/apps/ui/src/shell/TemplateConflictPrompt.vue
@@ -40,7 +40,11 @@ const { bundle } = useConfigBundle();
 const auth = useAuthStore();
 const { edits } = useLocalTemplateEdits();
 
-const canEditLayers = computed<boolean>(() => auth.hasVerb('dashboard:read'));
+// Both checks are `:write` for symmetry — the prompt nudges operators
+// who can act on the draft (publish or discard). `dashboard:read` would
+// resolve to the same roles in the default policy today, but a role with
+// read-only dashboard access shouldn't be nagged about edits it can't push.
+const canEditLayers = computed<boolean>(() => auth.hasVerb('dashboard:write'));
 const canEditOverviews = computed<boolean>(() => auth.hasVerb('overview:write'));
 
 interface DraftItem {

--- a/apps/ui/src/state/auth.ts
+++ b/apps/ui/src/state/auth.ts
@@ -42,6 +42,16 @@ export const useAuthStore = defineStore('auth', () => {
       user.value = await bffClient.session.login(username, password);
       // New login session → re-prompt the local-vs-remote template choice.
       useTemplatePreference().reset();
+      // Clear the per-session "unpublished local edits" prompt dismissal
+      // so a fresh login sees the reminder reliably. Without this, a
+      // dismissal from an earlier session in the same browser tab keeps
+      // the modal hidden across the logout / login boundary — operators
+      // log back in to find drafts they pushed nothing about.
+      try {
+        sessionStorage.removeItem('horizon:localDraftPrompt:dismissed');
+      } catch {
+        /* private mode — module-level state still resets on AppShell re-mount */
+      }
       return true;
     } catch (err) {
       if (err instanceof BffApiError && err.status === 401) {


### PR DESCRIPTION
## Two related fixes to the "You have unpublished local edits" prompt

### 1. Re-show after login
The prompt's `dismissed` flag is initialised from `sessionStorage` at component construction:

```ts
const dismissed = ref<boolean>(
  typeof sessionStorage !== 'undefined' && sessionStorage.getItem(SESSION_KEY) === '1',
);
```

`sessionStorage` is per-tab, not per-login — it survives logout / login in the same browser tab. So an operator who dismissed the modal earlier could log back in, find drafts they hadn't pushed, and never get reminded.

**Fix:** [`apps/ui/src/state/auth.ts`](apps/ui/src/state/auth.ts) — `login()` now clears the prompt's session key on every successful login, right next to the existing `useTemplatePreference().reset()`. Since `/login` lives outside AppShell, the next AppShell mount re-reads the (now-clean) sessionStorage and the modal opens reliably whenever drafts exist.

### 2. Align verb gates to `:write`
[`apps/ui/src/shell/TemplateConflictPrompt.vue`](apps/ui/src/shell/TemplateConflictPrompt.vue) — the layer-draft gate was `dashboard:read` while the overview-draft gate was `overview:write`. Comment-of-record above the component says *"kinds the user can edit"*, so symmetric `:write` is the intended semantic. Bumped to `dashboard:write` for the layer gate.

No behaviour change against the default policy — `dashboard:read` and `dashboard:write` resolve to the same roles (operator + admin) today. The change matters only against a custom policy that grants read-only dashboard access; that role would have seen the prompt without being able to act on it.

## Behaviour after the PR

| Role | Sees prompt? | Notes |
|---|:-:|---|
| viewer | ❌ | No relevant write verbs; can't push drafts anyway. |
| maintainer | ❌ | Same as viewer for these verbs. |
| operator | ✅ | Reliably re-shown on every fresh login. |
| admin | ✅ | Reliably re-shown on every fresh login. |

- **Dismiss within a session** → stays dismissed across in-app navigations (unchanged).
- **Hard refresh while logged in** → sessionStorage retained, stays dismissed (unchanged).
- **Logout → login (same tab)** → sessionStorage cleared by `login()`, prompt re-shows. (Was the bug.)

## Validation
- `pnpm --filter ui run type-check` ✓
- `pnpm --filter ui run test:unit` — 5 files / 69 tests ✓
- eslint on changed files ✓
- `license-eye header check` — 0 invalid ✓