### PR TITLE
fix(logs): log-entry popout reads cramped — min-height + wider cap

### DIFF
--- a/apps/ui/src/layer/logs/LayerLogsView.vue
+++ b/apps/ui/src/layer/logs/LayerLogsView.vue
@@ -1540,7 +1540,8 @@ function jumpToTrace(traceId: string, ts?: number): void {
 }
 .lg-popout {
   width: min(1100px, 92vw);
-  max-height: 86vh;
+  min-height: 70vh;
+  max-height: 92vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary

`.lg-popout` only set `max-height: 86vh` (a cap, not a target). With short payloads — e.g. a one-line TEXT log plus a few key/value tags — the flex column collapsed to natural content height (~300px) and the modal rendered as a small toast in the middle of the viewport, nowhere near the 86vh budget.

`.lg-popout-body` already had `flex: 1` — it just had no parent height to absorb.

Add `min-height: 70vh` so the box is visually consistent across short and long logs, and bump the cap from `86vh` to `92vh` to give long payloads more room. The body's existing `flex: 1` claims the extra space cleanly.

## Test plan

- [ ] Open a log row whose content is a single short line (e.g. INFO `Listing top songs`) → popout fills ~70% of the viewport height instead of collapsing to ~300px.
- [ ] Open a log row with a multi-line JSON / YAML payload → popout grows up to 92vh; body scrolls internally past that.
- [ ] Resize the browser window vertically → the popout tracks the new viewport (70vh floor stays proportional).
- [ ] Backdrop click and × button still close the popout.