### PR TITLE
fix: slide session cookie maxAge + clear 3D selection on empty-plane click

### DIFF
--- a/apps/bff/src/user/middleware.ts
+++ b/apps/bff/src/user/middleware.ts
@@ -60,6 +60,20 @@ export function requireAuth(deps: AuthDeps) {
       return void reply.code(401).send({ error: 'unauthenticated' });
     }
     req.session = session;
+    // Sliding session: touch() just slid the server-side TTL, so
+    // re-stamp the cookie's maxAge to match. The cookie's expiry was
+    // set only at login, so without this an actively-used session still
+    // expires in the browser at login + ttl while the server believes
+    // it's alive — the user is logged out mid-session. Mirror the login
+    // cookie options exactly so only maxAge slides.
+    const s = deps.config.current.session;
+    reply.setCookie(s.cookieName, sid, {
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: s.cookieSecure,
+      path: '/',
+      maxAge: s.ttlMinutes * 60,
+    });
   };
 }
 

--- a/apps/ui/src/features/infra-3d/Infra3DScene.vue
+++ b/apps/ui/src/features/infra-3d/Infra3DScene.vue
@@ -808,6 +808,9 @@ function onNodePointerOut(node: SceneServiceNode): void {
  * safe).
  */
 function onNodeClick(node: SceneServiceNode): void {
+  // Stamp so the canvas-host pointerup handler knows a cube absorbed
+  // this gesture and must not treat the same release as an empty click.
+  lastCubeClickAt = performance.now();
   dbgBadge(`CUBE CLICKED → ${node.shortName}`, '#f97316', `(${node.layerKey})`);
   dbg('node.pointerdown', {
     shortName: node.shortName,
@@ -853,12 +856,30 @@ function nodeHandlers(node: SceneServiceNode): NodeHandlers {
   return h;
 }
 
-/** Fired by TresCanvas when a pointer event hits nothing in the
- *  scene — the pmndrs "pointer-missed" pattern. Empty-space click =
- *  clear the current selection. */
-function onPointerMissed(): void {
-  dbg('canvas.pointermissed', { selected: props.selectedNodeId });
-  emit('select', null);
+// Empty-space deselect. pmndrs `pointermissed` only fires on a true
+// void hit (the ray hits nothing) — clicking a colored zone/tier plane
+// hits the plane (raycast stays on so planes occlude cubes), so it
+// never cleared the selection. We can't add a deselect handler to the
+// planes either: operators orbit-drag FROM empty plane space to rotate
+// WITHOUT changing selection (see CLAUDE.md). So detect an empty click
+// at the DOM level on the canvas itself, with three guards:
+//   - target is the <canvas> (not a portaled <Html> overlay like the
+//     detail card — clicking the card must not deselect)
+//   - the pointer barely moved (a click, not an orbit/pan drag)
+//   - no cube absorbed this gesture (onNodeClick stamped recently)
+let lastCubeClickAt = 0;
+let pointerDownX = 0;
+let pointerDownY = 0;
+const CLICK_SLOP_PX = 5;
+function onHostPointerDown(e: PointerEvent): void {
+  pointerDownX = e.clientX;
+  pointerDownY = e.clientY;
+}
+function onHostPointerUp(e: PointerEvent): void {
+  if ((e.target as HTMLElement | null)?.tagName !== 'CANVAS') return;
+  if (Math.hypot(e.clientX - pointerDownX, e.clientY - pointerDownY) > CLICK_SLOP_PX) return;
+  if (performance.now() - lastCubeClickAt < 120) return;
+  if (props.selectedNodeId !== null) emit('select', null);
 }
 
 // Diagnostic — fires whenever the parent updates `selectedNodeId`.
@@ -1116,13 +1137,17 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div ref="canvasHostEl" class="canvas-host">
+  <div
+    ref="canvasHostEl"
+    class="canvas-host"
+    @pointerdown="onHostPointerDown"
+    @pointerup="onHostPointerUp"
+  >
     <TresCanvas
       clear-color="#0a0d12"
       :antialias="true"
       power-preference="high-performance"
       @loop="onSceneLoop"
-      @pointermissed="onPointerMissed"
     >
       <TresPerspectiveCamera
         ref="cameraRef"


### PR DESCRIPTION
Two review-driven fixes (kept on one branch per request).

## 1. Sliding session cookie (auth)
The server slides a session's TTL on every authenticated request (`sessions.touch()`), but the session cookie's `maxAge` was stamped only at login. An actively-used session kept sliding server-side while the **browser** cookie still expired at `login + ttl` — so an active user was silently logged out mid-session. `requireAuth` now re-stamps the cookie (same options as login, only `maxAge` refreshed) after a successful `touch()`.

Validated: BFF type-check + lint; all 80 BFF unit tests pass.

## 2. Empty-space deselect in the 3D map
pmndrs `pointermissed` only fires on a true void hit (confirmed in TresJS source — it's a void-object click), so clicking a colored zone/tier plane (raycast left on so planes occlude cubes) never cleared the selection; only clicking past every plane did. A deselect handler on the planes isn't viable — operators orbit-drag *from* empty plane space to rotate without changing selection (per `Infra3DScene` CLAUDE.md).

Fix: detect the empty click at the DOM level on the canvas, guarded so it only fires for a genuine empty click — target is the `<canvas>` (not a portaled `<Html>` overlay), pointer barely moved (click, not drag), and no cube absorbed the gesture (`onNodeClick` stamped within 120ms). Replaces the `@pointermissed` wiring.

Validated: UI type-check + build + lint clean. ⚠ Needs a live click-test (select a cube → click empty plane → clears; orbit-drag from plane → keeps selection; click the detail card → stays open).

## Deferred (reported, not in this PR)
- **Admin edge styling** — valid, but `style: dashed` can't apply to the solid `TubeGeometry` edges without re-rendering them as dashed lines, and there's no `edges` accessor on the config composable yet. Needs a rendering rework, not a partial color-only wire.
- **Theme support** — valid limitation; the canvas/plane darks are hardcoded. A real fix needs a reactive re-read on theme switch + a contrast/emissive review (design pass).