### PR TITLE
Release 0.6.0, bump to 0.7.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ file-by-file implementation. For per-commit detail, see the git log.
 The version line is shared by every package in the monorepo (apps + shared
 packages) plus the BFF's `HORIZON_VERSION` default.
 
+## 0.7.0
+
+(In development — fill in highlights here before cutting the release.)
+
 ## 0.6.0
 
 This release is the production-readiness pass for Horizon UI: every page

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -263,7 +263,7 @@ if (staticDir && existsSync(staticDir)) {
 // admin status pages.
 app.get('/api/health', async () => ({
   status: 'ok',
-  version: process.env.HORIZON_VERSION ?? '0.6.0-dev',
+  version: process.env.HORIZON_VERSION ?? '0.6.0',
 }));
 
 const { host, port } = source.current.server;

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -263,7 +263,7 @@ if (staticDir && existsSync(staticDir)) {
 // admin status pages.
 app.get('/api/health', async () => ({
   status: 'ok',
-  version: process.env.HORIZON_VERSION ?? '0.6.0',
+  version: process.env.HORIZON_VERSION ?? '0.7.0-dev',
 }));
 
 const { host, port } = source.current.server;

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/setup/container-image.md
+++ b/docs/setup/container-image.md
@@ -15,7 +15,7 @@ Registry: **GitHub Container Registry (GHCR)** at `ghcr.io/apache/skywalking-hor
 | `main` | Head of `main`. Moves on every merge. | Smoke-test the development branch. |
 
 ```sh
-docker pull ghcr.io/apache/skywalking-horizon-ui:0.5.0
+docker pull ghcr.io/apache/skywalking-horizon-ui:0.6.0
 docker pull ghcr.io/apache/skywalking-horizon-ui:<sha>
 ```
 
@@ -65,7 +65,7 @@ docker run -d \
   --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
-  ghcr.io/apache/skywalking-horizon-ui:0.5.0
+  ghcr.io/apache/skywalking-horizon-ui:0.6.0
 ```
 
 Notes:
@@ -78,7 +78,7 @@ Notes:
 For immutable single-tenant deployments, build a child image that includes your config:
 
 ```dockerfile
-FROM ghcr.io/apache/skywalking-horizon-ui:0.5.0
+FROM ghcr.io/apache/skywalking-horizon-ui:0.6.0
 COPY horizon.yaml /app/horizon.yaml
 ```
 
@@ -146,7 +146,7 @@ spec:
         fsGroup: 101
       containers:
         - name: horizon
-          image: ghcr.io/apache/skywalking-horizon-ui:0.5.0
+          image: ghcr.io/apache/skywalking-horizon-ui:0.6.0
           ports:
             - containerPort: 8081
           envFrom:
@@ -188,7 +188,7 @@ docker run -d --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
   -v horizon-state:/data \
-  ghcr.io/apache/skywalking-horizon-ui:0.5.0
+  ghcr.io/apache/skywalking-horizon-ui:0.6.0
 ```
 
 Without a mounted volume the writes still land in the container's writable layer at `/data/` (ephemeral, but at least non-failing). Mounting a volume is what makes them durable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/templates",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/templates",
-  "version": "0.6.0",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release branch for 0.6.0. Two commits:

1. `Prepare release 0.6.0` — strips `-dev` from every package
   marker + `apps/bff/src/server.ts`; advances container-image docs to
   `0.6.0`. Tagged `v0.6.0` (the release-candidate commit the
   vote runs against).
2. `Prepare next release 0.7.0-dev` — bumps every marker to
   `0.7.0-dev` and rotates CHANGELOG for the next cycle.

Merge after the [VOTE] passes so `main` returns to a `-dev`
version with the release in its history. The `v0.6.0` tag is immutable and
keeps pointing at commit 1 regardless of how this PR is merged.