### PR TITLE
feat(layers): add Airflow layer dashboards (SWIP-7)

### DIFF
--- a/apps/bff/src/bundled_templates/infra-3d/config.json
+++ b/apps/bff/src/bundled_templates/infra-3d/config.json
@@ -77,6 +77,7 @@
         "NGINX",
         "KONG",
         "FLINK",
+        "AIRFLOW",
         "SO11Y_OAP",
         "SO11Y_SATELLITE",
         "SO11Y_BANYANDB",
@@ -252,6 +253,10 @@
     "FLINK": {
       "color": "#e6526f",
       "load":  { "mqe": "latest(meter_flink_jobManager_running_job_number)", "label": "Running Jobs", "unit": "jobs" }
+    },
+    "AIRFLOW": {
+      "color": "#017cee",
+      "load":  { "mqe": "latest(meter_airflow_scheduler_tasks_executable)", "label": "Tasks Executable", "unit": "tasks" }
     },
     "SO11Y_OAP": {
       "color": "#69b1ff",

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.de.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "Workflow-Planer",
+  "slots": {
+    "services": "Airflow-Cluster",
+    "instances": "Komponenten"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "Cluster",
+        "metrics": [
+          { "label": "Ausführbare Tasks", "tip": "Tasks im Cluster, die zur Ausführung bereit sind." },
+          { "label": "Wartende Tasks", "tip": "Tasks, die auf dem Executor warten." },
+          { "label": "Freie Slots", "tip": "Verfügbare Executor-Slots." }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "Ausführbare Tasks" },
+      { "title": "Laufende Tasks" },
+      { "title": "Geplante Slots" },
+      { "title": "Wartende Tasks" },
+      { "title": "Freie Slots" },
+      {
+        "title": "Pool wartende / verzögerte / geplante Slots",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Scheduler-Heartbeat" },
+      {
+        "title": "Laufende Tasks / geplante Slots",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "DAG-Datei-Warteschlangengröße" },
+      { "title": "Asset-Updates" }
+    ],
+    "instance": [
+      {
+        "title": "Pool freie / verzögerte / laufende Slots",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Triggerer-Heartbeat" },
+      {
+        "title": "Trigger blockiert / erfolgreich",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "Laufende Tasks / geplante Slots",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Asset-Updates" },
+      { "title": "Durch Assets ausgelöste DagRuns" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.es.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "Programador de flujos de trabajo",
+  "slots": {
+    "services": "Clústeres de Airflow",
+    "instances": "Componentes"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "Clúster",
+        "metrics": [
+          { "label": "Tasks ejecutables", "tip": "Tasks listas para ejecutarse en el clúster." },
+          { "label": "Tasks en cola", "tip": "Tasks esperando en el executor." },
+          { "label": "Slots libres", "tip": "Slots de executor disponibles." }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "Tasks ejecutables" },
+      { "title": "Tasks en ejecución" },
+      { "title": "Slots programados" },
+      { "title": "Tasks en cola" },
+      { "title": "Slots libres" },
+      {
+        "title": "Slots en cola / diferidos / programados del pool",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Heartbeat del scheduler" },
+      {
+        "title": "Tasks en ejecución / slots programados",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Tamaño de cola de archivos DAG" },
+      { "title": "Actualizaciones de assets" }
+    ],
+    "instance": [
+      {
+        "title": "Slots abiertos / diferidos / en ejecución del pool",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Heartbeat del triggerer" },
+      {
+        "title": "Triggers bloqueados / exitosos",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "Tasks en ejecución / slots programados",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Actualizaciones de assets" },
+      { "title": "DagRuns disparados por assets" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.fr.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "Planificateur de workflow",
+  "slots": {
+    "services": "Clusters Airflow",
+    "instances": "Composants"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "Cluster",
+        "metrics": [
+          { "label": "Tâches exécutables", "tip": "Tâches prêtes à être exécutées dans le cluster." },
+          { "label": "Tâches en file", "tip": "Tâches en attente sur l'executor." },
+          { "label": "Slots libres", "tip": "Slots d'executor disponibles." }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "Tâches exécutables" },
+      { "title": "Tâches en cours" },
+      { "title": "Slots planifiés" },
+      { "title": "Tâches en file" },
+      { "title": "Slots libres" },
+      {
+        "title": "Slots en file / différés / planifiés du pool",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Heartbeat du scheduler" },
+      {
+        "title": "Tâches en cours / slots planifiés",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Taille de la file de fichiers DAG" },
+      { "title": "Mises à jour d'assets" }
+    ],
+    "instance": [
+      {
+        "title": "Slots ouverts / différés / en cours du pool",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Heartbeat du triggerer" },
+      {
+        "title": "Triggers bloqués / réussis",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "Tâches en cours / slots planifiés",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Mises à jour d'assets" },
+      { "title": "DagRuns déclenchés par assets" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.ja.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "ワークフロースケジューラ",
+  "slots": {
+    "services": "Airflow クラスタ",
+    "instances": "コンポーネント"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "クラスタ",
+        "metrics": [
+          { "label": "実行可能タスク", "tip": "クラスタ全体で実行待ちのタスク数。" },
+          { "label": "キュー待ちタスク", "tip": "Executor で待機中のタスク数。" },
+          { "label": "空きスロット", "tip": "利用可能な Executor スロット数。" }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "実行可能タスク" },
+      { "title": "実行中タスク" },
+      { "title": "スケジュール済みスロット" },
+      { "title": "キュー待ちタスク" },
+      { "title": "空きスロット" },
+      {
+        "title": "Pool キュー / 延期 / スケジュール済みスロット",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Scheduler ハートビート" },
+      {
+        "title": "実行中タスク / スケジュール済みスロット",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "DAG ファイルキューサイズ" },
+      { "title": "Asset 更新" }
+    ],
+    "instance": [
+      {
+        "title": "Pool 空き / 延期 / 実行中スロット",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Triggerer ハートビート" },
+      {
+        "title": "Trigger ブロック / 成功",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "実行中タスク / スケジュール済みスロット",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Asset 更新" },
+      { "title": "Asset トリガー DagRun" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.ko.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "워크플로 스케줄러",
+  "slots": {
+    "services": "Airflow 클러스터",
+    "instances": "컴포넌트"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "클러스터",
+        "metrics": [
+          { "label": "실행 가능 작업", "tip": "클러스터 전체에서 실행 대기 중인 작업 수." },
+          { "label": "대기 작업", "tip": "Executor에서 대기 중인 작업 수." },
+          { "label": "사용 가능 슬롯", "tip": "사용 가능한 Executor 슬롯 수." }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "실행 가능 작업" },
+      { "title": "실행 중 작업" },
+      { "title": "예약된 슬롯" },
+      { "title": "대기 작업" },
+      { "title": "사용 가능 슬롯" },
+      {
+        "title": "Pool 대기 / 지연 / 예약 슬롯",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Scheduler 하트비트" },
+      {
+        "title": "실행 중 작업 / 예약 슬롯",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "DAG 파일 큐 크기" },
+      { "title": "Asset 업데이트" }
+    ],
+    "instance": [
+      {
+        "title": "Pool 사용 가능 / 지연 / 실행 중 슬롯",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Triggerer 하트비트" },
+      {
+        "title": "Trigger 차단 / 성공",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "실행 중 작업 / 예약 슬롯",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Asset 업데이트" },
+      { "title": "Asset 트리거 DagRun" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.pt.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "Agendador de workflow",
+  "slots": {
+    "services": "Clusters Airflow",
+    "instances": "Componentes"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "Cluster",
+        "metrics": [
+          { "label": "Tasks executáveis", "tip": "Tasks prontas para execução no cluster." },
+          { "label": "Tasks enfileiradas", "tip": "Tasks aguardando no executor." },
+          { "label": "Slots livres", "tip": "Slots de executor disponíveis." }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "Tasks executáveis" },
+      { "title": "Tasks em execução" },
+      { "title": "Slots agendados" },
+      { "title": "Tasks enfileiradas" },
+      { "title": "Slots livres" },
+      {
+        "title": "Slots enfileirados / adiados / agendados do pool",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Heartbeat do scheduler" },
+      {
+        "title": "Tasks em execução / slots agendados",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Tamanho da fila de arquivos DAG" },
+      { "title": "Atualizações de assets" }
+    ],
+    "instance": [
+      {
+        "title": "Slots abertos / adiados / em execução do pool",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Heartbeat do triggerer" },
+      {
+        "title": "Triggers bloqueados / bem-sucedidos",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "Tasks em execução / slots agendados",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Atualizações de assets" },
+      { "title": "DagRuns disparados por assets" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.i18n.zh-CN.json
@@ -1,0 +1,57 @@
+{
+  "alias": "Airflow",
+  "group": "工作流调度",
+  "slots": {
+    "services": "Airflow 集群",
+    "instances": "组件"
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "集群",
+        "metrics": [
+          { "label": "可执行任务", "tip": "集群内待执行的任务数。" },
+          { "label": "排队任务", "tip": "Executor 上排队等待的任务数。" },
+          { "label": "空闲 Slot", "tip": "Executor 可用 slot 数。" }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      { "title": "可执行任务" },
+      { "title": "运行中任务" },
+      { "title": "已调度 Slot" },
+      { "title": "排队任务" },
+      { "title": "空闲 Slot" },
+      {
+        "title": "Pool 排队 / 延迟 / 已调度 Slot",
+        "expressionLabels": ["queued", "deferred", "scheduled"]
+      },
+      { "title": "Scheduler 心跳" },
+      {
+        "title": "运行中任务 / 已调度 Slot",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "DAG 文件队列大小" },
+      { "title": "Asset 更新" }
+    ],
+    "instance": [
+      {
+        "title": "Pool 空闲 / 延迟 / 运行 Slot",
+        "expressionLabels": ["open", "deferred", "running"]
+      },
+      { "title": "Triggerer 心跳" },
+      {
+        "title": "Trigger 阻塞 / 成功",
+        "expressionLabels": ["blocked", "succeeded"]
+      },
+      {
+        "title": "运行中任务 / 已调度 Slot",
+        "expressionLabels": ["running tasks", "scheduled slots"]
+      },
+      { "title": "Asset 更新" },
+      { "title": "Asset 触发的 DagRun" }
+    ]
+  }
+}

--- a/apps/bff/src/bundled_templates/layers/airflow.json
+++ b/apps/bff/src/bundled_templates/layers/airflow.json
@@ -1,0 +1,273 @@
+{
+  "key": "AIRFLOW",
+  "alias": "Airflow",
+  "group": "Workflow Scheduler",
+  "color": "var(--sw-cyan)",
+  "documentLink": "https://skywalking.apache.org/docs/main/next/en/setup/backend/backend-airflow-monitoring/",
+  "aliases": {
+    "services": "Airflow clusters",
+    "instances": "Components"
+  },
+  "components": {
+    "service": true,
+    "instances": true,
+    "endpoints": false,
+    "topology": false,
+    "traces": false,
+    "logs": false
+  },
+  "overview": {
+    "groups": [
+      {
+        "title": "Cluster",
+        "size": "auto",
+        "metrics": [
+          {
+            "id": "tasksExecutable",
+            "label": "Tasks Executable",
+            "tip": "Tasks ready for execution across the cluster.",
+            "mqe": "latest(meter_airflow_scheduler_tasks_executable)",
+            "aggregation": "sum"
+          },
+          {
+            "id": "queuedTasks",
+            "label": "Queued Tasks",
+            "tip": "Tasks waiting on the executor.",
+            "mqe": "latest(meter_airflow_executor_queued_tasks)",
+            "aggregation": "sum"
+          },
+          {
+            "id": "openSlots",
+            "label": "Open Slots",
+            "tip": "Free executor slots.",
+            "mqe": "latest(meter_airflow_executor_open_slots)",
+            "aggregation": "sum"
+          }
+        ]
+      }
+    ]
+  },
+  "dashboards": {
+    "service": [
+      {
+        "id": "tasks_executable",
+        "title": "Tasks Executable",
+        "type": "card",
+        "expressions": [
+          "latest(meter_airflow_scheduler_tasks_executable)"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
+        "id": "running_tasks",
+        "title": "Running Tasks",
+        "type": "card",
+        "expressions": [
+          "latest(meter_airflow_executor_running_tasks)"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
+        "id": "scheduled_slots",
+        "title": "Scheduled Slots",
+        "type": "card",
+        "expressions": [
+          "latest(meter_airflow_pool_scheduled_slots)"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
+        "id": "queued_tasks",
+        "title": "Queued Tasks",
+        "type": "card",
+        "expressions": [
+          "latest(meter_airflow_executor_queued_tasks)"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
+        "id": "open_slots",
+        "title": "Open Slots",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_executor_open_slots"
+        ],
+        "span": 4,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "pool_slots",
+        "title": "Pool Queued / Deferred Slots",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_pool_queued_slots",
+          "meter_airflow_pool_deferred_slots",
+          "meter_airflow_pool_scheduled_slots"
+        ],
+        "expressionLabels": [
+          "queued",
+          "deferred",
+          "scheduled"
+        ],
+        "span": 4,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "scheduler_heartbeat",
+        "title": "Scheduler Heartbeat",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_scheduler_heartbeat"
+        ],
+        "span": 4,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "running_tasks_trend",
+        "title": "Running Tasks / Scheduled Slots",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_executor_running_tasks",
+          "meter_airflow_pool_scheduled_slots"
+        ],
+        "expressionLabels": [
+          "running tasks",
+          "scheduled slots"
+        ],
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "dag_file_queue",
+        "title": "DAG File Queue Size",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_dag_file_queue_size"
+        ],
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "asset_updates",
+        "title": "Asset Updates",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_asset_updates"
+        ],
+        "span": 12,
+        "rowSpan": 2,
+        "format": "int"
+      }
+    ],
+    "instance": [
+      {
+        "id": "pool_slots",
+        "title": "Pool Open / Deferred / Running Slots",
+        "tip": "Celery worker pool capacity. Reported by worker processes only.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_pool_open_slots",
+          "meter_airflow_instance_pool_deferred_slots",
+          "meter_airflow_instance_pool_running_slots"
+        ],
+        "expressionLabels": [
+          "open",
+          "deferred",
+          "running"
+        ],
+        "visibleWhen": "meter_airflow_instance_pool_open_slots has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "triggerer_heartbeat",
+        "title": "Triggerer Heartbeat",
+        "tip": "Triggerer process heartbeats per minute.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_triggerer_heartbeat"
+        ],
+        "visibleWhen": "meter_airflow_instance_triggerer_heartbeat has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "triggers",
+        "title": "Triggers Blocked / Succeeded",
+        "tip": "Deferred trigger outcomes on the triggerer host.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_triggers_blocked_main_thread",
+          "meter_airflow_instance_triggers_succeeded"
+        ],
+        "expressionLabels": [
+          "blocked",
+          "succeeded"
+        ],
+        "visibleWhen": "meter_airflow_instance_triggers_succeeded has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "running_tasks",
+        "title": "Running Tasks / Scheduled Slots",
+        "tip": "Scheduler executor queue depth and pool slots waiting to run.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_executor_running_tasks",
+          "meter_airflow_instance_pool_scheduled_slots"
+        ],
+        "expressionLabels": [
+          "running tasks",
+          "scheduled slots"
+        ],
+        "visibleWhen": "meter_airflow_instance_executor_running_tasks has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "asset_updates",
+        "title": "Asset Updates",
+        "tip": "Dataset/asset update events on this host.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_asset_updates"
+        ],
+        "visibleWhen": "meter_airflow_instance_asset_updates has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      },
+      {
+        "id": "asset_triggered",
+        "title": "Asset Triggered DagRuns",
+        "tip": "DagRuns triggered by dataset events on the scheduler.",
+        "type": "line",
+        "expressions": [
+          "meter_airflow_instance_asset_triggered_dagruns"
+        ],
+        "visibleWhen": "meter_airflow_instance_asset_triggered_dagruns has value",
+        "span": 6,
+        "rowSpan": 2,
+        "format": "int"
+      }
+    ]
+  }
+}

--- a/apps/bff/src/http/query/instance.ts
+++ b/apps/bff/src/http/query/instance.ts
@@ -90,6 +90,12 @@ export interface InstanceRow {
   attributes: Array<{ name: string; value: string }>;
 }
 
+/** OAP defaults to Language.UNKNOWN when no agent language is registered (e.g. Airflow OTLP). */
+function normalizeInstanceLanguage(language: string | null | undefined): string | null {
+  if (!language) return null;
+  return language.trim().toUpperCase() === 'UNKNOWN' ? null : language;
+}
+
 export interface InstancesResponse {
   layer: string;
   service: string;
@@ -165,7 +171,7 @@ export function registerInstanceRoute(app: FastifyInstance, deps: InstanceRouteD
         const rows: InstanceRow[] = (data.instances ?? []).map((i) => ({
           id: i.id,
           name: i.name,
-          language: i.language ?? null,
+          language: normalizeInstanceLanguage(i.language),
           attributes: i.attributes ?? [],
         }));
         return reply.send({

--- a/apps/ui/src/features/infra-3d/composables/useScenePlacement.ts
+++ b/apps/ui/src/features/infra-3d/composables/useScenePlacement.ts
@@ -133,6 +133,7 @@ export function tintForLayer(layerKey: string, group: string | null): ZoneTint {
     return 'db';
   }
   if (k === 'redis') return 'cache';
+  if (group === 'Workflow Scheduler' || k === 'airflow') return 'misc';
   if (group === 'MQ' || ['kafka', 'rocketmq', 'rabbitmq', 'activemq', 'pulsar', 'bookkeeper', 'flink'].includes(k)) {
     return 'mq';
   }

--- a/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
+++ b/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
@@ -78,6 +78,12 @@ const { selectedId } = useSelectedService();
 const { layers } = useLayers();
 const layer = computed<LayerDef | null>(() => layers.value.find((l) => l.key === layerKey.value) ?? null);
 const instanceSlotLabel = computed(() => layer.value?.slots?.instances ?? 'Instance');
+const instanceEmptyHint = computed(() => {
+  if (layerKey.value === 'AIRFLOW') {
+    return 'Ensure Airflow OpenTelemetry export is enabled and scheduler / worker / triggerer hosts report metrics with host.name in the active time window.';
+  }
+  return 'Keep the app running with native meter and set APP_VERSION or SW_AGENT_INSTANCE_NAME.';
+});
 
 const store = useSetupStore();
 const safeLayer = computed<LayerDef>(() => layer.value ?? {
@@ -697,8 +703,7 @@ function isVisible(
     <div v-if="reachable && dashboardUpstreamBlocked" class="empty">
       <template v-if="scope === 'instance'">
         No {{ instanceSlotLabel.toLowerCase() }} to chart for <b>{{ serviceName }}</b>.
-        Keep the app running with native meter and set
-        <code>APP_VERSION</code> or <code>SW_AGENT_INSTANCE_NAME</code>.
+        {{ instanceEmptyHint }}
       </template>
       <template v-else-if="scope === 'endpoint'">
         No endpoints to chart for <b>{{ serviceName }}</b> in the active window.

--- a/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
+++ b/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
@@ -77,6 +77,7 @@ const scope = computed<string>(() => {
 const { selectedId } = useSelectedService();
 const { layers } = useLayers();
 const layer = computed<LayerDef | null>(() => layers.value.find((l) => l.key === layerKey.value) ?? null);
+const instanceSlotLabel = computed(() => layer.value?.slots?.instances ?? 'Instance');
 
 const store = useSetupStore();
 const safeLayer = computed<LayerDef>(() => layer.value ?? {
@@ -385,6 +386,21 @@ watch(data, (d) => {
 });
 const dataIsFresh = computed(() => lastFreshKey.value === fetchKey.value);
 
+// Terminal upstream state: service resolved but no instance / endpoint
+// to drill into. The widget batch stays disabled (see useLayerDashboard
+// `enabled`), so `dataIsFresh` never flips — without this gate the main
+// zone would spin "Reading data…" forever.
+const dashboardUpstreamBlocked = computed(() => {
+  if (!serviceName.value) return false;
+  if (scope.value === 'instance') {
+    return !instancesLoading.value && instanceList.value.length === 0;
+  }
+  if (scope.value === 'endpoint') {
+    return !endpointsLoading.value && endpointList.value.length === 0;
+  }
+  return false;
+});
+
 const resultsById = computed(() => {
   const out = new Map<string, NonNullable<typeof data.value>['widgets'][number]>();
   // Only surface widget results from a response that matches the
@@ -521,13 +537,14 @@ function isVisible(
 
     <!-- Instance picker — a sticky list on the left when the Instance
          scope is active. Each row shows the instance name, language
-         tag, and an expandable attributes property list. Auto-fires
+         tag when OAP reports a known agent language (JAVA, PYTHON, …),
+         and an expandable attributes property list. Auto-fires
          once a service is selected (no manual trigger). When no
          service is picked, we show a hint and gate the widget grid
          so a stale instance can't sneak into queries. -->
     <section v-if="scope === 'instance'" class="instance-bar sw-card">
       <header class="ib-head">
-        <span class="kicker">Instance</span>
+        <span class="kicker">{{ instanceSlotLabel }}</span>
         <!-- Header strictly tracks the resolved `serviceName` —
              never the raw `?service=` base64 id from the URL.
              While landing is still loading we show a loading hint
@@ -677,7 +694,17 @@ function isVisible(
          sequence (which read as a slow, jumpy entry). The "no widgets"
          branch below only shows once config has actually loaded and the
          layer genuinely defines none. -->
-    <div v-if="reachable && (configLoading || !dataIsFresh)" class="empty reading">
+    <div v-if="reachable && dashboardUpstreamBlocked" class="empty">
+      <template v-if="scope === 'instance'">
+        No {{ instanceSlotLabel.toLowerCase() }} to chart for <b>{{ serviceName }}</b>.
+        Keep the app running with native meter and set
+        <code>APP_VERSION</code> or <code>SW_AGENT_INSTANCE_NAME</code>.
+      </template>
+      <template v-else-if="scope === 'endpoint'">
+        No endpoints to chart for <b>{{ serviceName }}</b> in the active window.
+      </template>
+    </div>
+    <div v-else-if="reachable && (configLoading || !dataIsFresh)" class="empty reading">
       <span class="reading-dot" />
       <span>
         Reading data


### PR DESCRIPTION
## Summary

- Add bundled `AIRFLOW` layer template with Service and Instance dashboards aligned with [SWIP-7](https://github.com/apache/skywalking/blob/master/docs/en/swip/SWIP-7.md) MQE metrics.
- Ship i18n overlays for all seven non-English locales (de, es, fr, ja, ko, pt, zh-CN) and register the layer in the infra-3D scene.
- Fix Components-tab empty state so AIRFLOW no longer shows the Dart-only APP_VERSION hint.

Companion OAP PR: https://github.com/songzhendong/skywalking/tree/feature/swip-7-airflow-monitoring

## Test plan

- [x] `pnpm --filter @skywalking-horizon-ui/bff run i18n:validate`
- [x] `pnpm --filter @skywalking-horizon-ui/bff exec vitest run src/logic/layers/loader.test.ts`
- [ ] Manual: switch locales in Horizon UI and verify Airflow sidebar group, dashboard titles, and overview KPIs
- [ ] Manual: open `/layer/airflow/service` and `/layer/airflow/instance` against a live OAP with AIRFLOW metrics
