### PR TITLE
fix(layer): resolve top-N compare sort direction from the MQE, not the data

### DIFF
--- a/apps/bff/src/logic/layers/loader.test.ts
+++ b/apps/bff/src/logic/layers/loader.test.ts
@@ -94,6 +94,19 @@ describe('widgetsForScope — scope-resolution + fallback chain', () => {
     expect(widgetsForScope(t, 'service')).toEqual([]);
     expect(widgetsForScope(t, 'instance')).toBe(instance);
   });
+
+  it('resolves topNOrder on top / record widgets from their top_n() expression', () => {
+    const top: DashboardWidget = {
+      id: 'sla',
+      title: 'Top instances by success rate',
+      type: 'top',
+      expressions: ['top_n(service_instance_sla,10,asc)/100'],
+    };
+    const line = widget('cpm-line'); // non-top widget rides through untouched
+    const out = widgetsForScope(tpl({ dashboards: { service: [top, line] } }), 'service');
+    expect(out.find((w) => w.id === 'sla')?.topNOrder).toBe('asc');
+    expect(out.find((w) => w.id === 'cpm-line')).toBe(line); // unchanged reference
+  });
 });
 
 describe('topologyConfigFor / endpointDependencyConfigFor / tracesConfigFor — defaults', () => {

--- a/apps/bff/src/logic/layers/loader.ts
+++ b/apps/bff/src/logic/layers/loader.ts
@@ -560,14 +560,40 @@ function load(): Map<string, LayerTemplate> {
   return out;
 }
 
-/** Resolve the widget set for a given scope, falling back to service. */
+/** Sort direction (`asc`/`des`) of the FIRST `top_n(…)` expression in the
+ *  list, or `undefined` when none declares one. Resolved here at template
+ *  time so the UI never parses MQE or guesses direction from the data —
+ *  today top_n's order is a plain literal arg: `top_n(<metric>, <N>, asc|des)`. */
+export function topNOrderOf(
+  expressions: readonly string[] | undefined,
+): 'asc' | 'des' | undefined {
+  for (const e of expressions ?? []) {
+    const m = /\btop_n\s*\([^)]*,\s*(asc|des)\b/i.exec(e);
+    if (m) return m[1].toLowerCase() as 'asc' | 'des';
+  }
+  return undefined;
+}
+
+/** Resolve the widget set for a given scope, falling back to service.
+ *  Enriches `top` / `record` widgets with the resolved `topNOrder` (from
+ *  their first `top_n(…)`) so the multi-entity compare grid merges the
+ *  per-entity "All" list in the MQE's own direction — without the UI parsing
+ *  MQE or inferring asc/des from one entity's (possibly flat) values. */
 export function widgetsForScope(
   template: LayerTemplate,
   scope: DashboardScope,
 ): DashboardWidget[] {
   const d = template.dashboards;
-  if (!d) return template.widgets ?? [];
-  return d[scope] ?? d.service ?? template.widgets ?? [];
+  const raw = !d ? (template.widgets ?? []) : (d[scope] ?? d.service ?? template.widgets ?? []);
+  // Pass the resolved array straight through unless a top / record widget
+  // needs its sort direction resolved — keeps the common case allocation-free
+  // (and reference-stable) and only copies the widgets that gain `topNOrder`.
+  if (!raw.some((w) => w.type === 'top' || w.type === 'record')) return raw;
+  return raw.map((w) => {
+    if (w.type !== 'top' && w.type !== 'record') return w;
+    const order = topNOrderOf(w.expressions);
+    return order ? { ...w, topNOrder: order } : w;
+  });
 }
 
 /** Resolve the topology config — operator override if present, else

--- a/apps/bff/src/logic/layers/topNOrder.test.ts
+++ b/apps/bff/src/logic/layers/topNOrder.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { topNOrderOf } from './loader';
+
+describe('topNOrderOf — resolve top_n sort direction from the MQE', () => {
+  it('reads the explicit asc / des argument', () => {
+    expect(topNOrderOf(['top_n(service_instance_sla,10,asc)/100'])).toBe('asc');
+    expect(topNOrderOf(['top_n(endpoint_cpm,20,des)'])).toBe('des');
+  });
+
+  it('takes the FIRST top_n expression when several are present (tab-switch widgets)', () => {
+    // The compare grid merges the first expression (topGroups[0]), so its order wins.
+    expect(
+      topNOrderOf(['top_n(endpoint_cpm,20,des)', 'top_n(endpoint_sla,20,asc)/100']),
+    ).toBe('des');
+  });
+
+  it('tolerates whitespace and case', () => {
+    expect(topNOrderOf(['top_n( service_instance_sla , 10 , ASC )/100'])).toBe('asc');
+  });
+
+  it('is undefined when no order argument is declared', () => {
+    expect(topNOrderOf(['top_n(service_instance_cpm,10)'])).toBeUndefined();
+  });
+
+  it('is undefined for non-top_n expressions (record sources, plain metrics)', () => {
+    expect(topNOrderOf(['top_n_service_database_statement'])).toBeUndefined();
+    expect(topNOrderOf(['service_instance_cpm'])).toBeUndefined();
+  });
+
+  it('is undefined for empty / missing input', () => {
+    expect(topNOrderOf([])).toBeUndefined();
+    expect(topNOrderOf(undefined)).toBeUndefined();
+  });
+});

--- a/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
+++ b/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
@@ -662,15 +662,16 @@ interface TopGroup {
   expression: string;
   items: TopItem[];
 }
-// "All" follows the response's own asc/desc (MQE-fixed) then prefixes the
-// entity; per-entity groups keep each entity's native order.
+// "All" merges every entity's rows and re-sorts them in the widget's OWN
+// MQE direction; per-entity groups keep each entity's native order. The
+// direction is resolved BFF-side at template time (`topNOrder`), NOT inferred
+// from the data — inferring from one probe entity flips the sort when that
+// entity's values are flat/equal (e.g. instances all at 100% success rate) or
+// when no entity has ≥2 rows. Default `des` for record widgets / expressions
+// without an explicit order.
 function multiTopGroups(wid: string): TopGroup[] {
   const ents = compareEntities.value;
-  // Detect the MQE's fixed asc/desc from the FIRST entity that actually has
-  // >=2 items — probing only ents[0] inverts the merged sort when the primary
-  // happens to be sparse while a pinned entity carries the full ranking.
-  const probe = ents.map((e) => topItemsFor(wid, e)).find((it) => it.length >= 2) ?? [];
-  const desc = probe.length < 2 || (probe[0].value ?? 0) >= (probe[probe.length - 1].value ?? 0);
+  const desc = widgets.value.find((w) => w.id === wid)?.topNOrder !== 'asc';
   const all: TopItem[] = ents.flatMap((e) =>
     topItemsFor(wid, e).map((it) => ({ name: `${entityLabel(e)} · ${it.name}`, value: it.value })),
   );

--- a/packages/api-client/src/dashboard.ts
+++ b/packages/api-client/src/dashboard.ts
@@ -205,6 +205,12 @@ export interface DashboardWidget {
    *  multi-entity compare; the remainder fold into one `(others)` row.
    *  Defaults to 8. */
   labelTopN?: number;
+  /** Sort direction of the widget's first `top_n(…)` expression, resolved
+   *  BFF-side at template-resolve time (not inferred from data). Lets the
+   *  multi-entity compare grid merge the per-entity "All" list in the MQE's
+   *  own order — `asc` (worst/lowest first, e.g. success-rate) vs `des`.
+   *  Absent for non-`top_n` widgets; the UI then falls back to `des`. */
+  topNOrder?: 'asc' | 'des';
   /** Legacy 24-col grid coordinates — kept for back-compat during the
    *  span-based flow-layout migration. New widgets should leave these
    *  unset and use `span` / `rowSpan` instead. */


### PR DESCRIPTION
## Why

In multi-entity compare, the merged **"All"** tab of a top-N widget inferred its asc/des direction from a single probe entity's values. That heuristic flips when the probe entity's values are flat/equal — e.g. **"Top 10 instances by success rate"** where one service's instances are all at `100%` — or when no entity has ≥2 rows (it defaults to descending).

Result: a `top_n(service_instance_sla,10,asc)` widget — deliberately **worst-first** for triage (lowest success ≈ highest error) — rendered **best-first** in the "All" list, while the per-entity tabs (native MQE order) stayed correct. (Two screenshots in the discussion: per-entity "App" tab ascending 42.9→52.6, but "All" descending 100→42.9.)

## What

Resolve the direction **BFF-side, at template-resolve time** — where MQE is understood — instead of guessing in the UI from data:

- `DashboardWidget.topNOrder?: 'asc' | 'des'` (api-client) — the resolved direction.
- `widgetsForScope` parses the first `top_n(…, asc|des)` of each `top`/`record` widget onto `topNOrder` (pass-through + reference-stable for everything else, so no per-call allocation when nothing needs it).
- The UI's `multiTopGroups` reads `topNOrder` (default `des`) and **drops the data-probe** — the UI no longer parses MQE or infers direction from one entity's (possibly flat) values.

This kills both failure modes (single-probe fragility + desc-on-ambiguity) at the source and keeps the UI MQE-agnostic. Top-N order is a plain literal arg today, so the parse is trivial and lives in the one place that understands MQE.

## Validation

- `pnpm -r run type-check` ✓ · UI + BFF `build` ✓ · `pnpm -r run lint` 0 ✓ · `pnpm -r run test:unit` — **BFF 116 / UI 116** ✓ (adds `topNOrderOf` parser tests: asc/des/missing-arg/non-top_n/empty, plus a `widgetsForScope` enrichment test) · `license:check` 0 invalid ✓.
- **Live OAP** (demo.skywalking.apache.org): the config route now serves `topNOrder` resolved from the stored template — `top_apis`/`top_instance_load`/`top_instance_slow`/`slow_statements` = `des`, **`top_instance_sla` = `asc`** (the bug case). So the "All" merge now ranks worst-first for success rate.
- No new UI strings (i18n unaffected). Follow-up to #53 (fixes a bug in that still-unreleased preview feature).