### PR TITLE
chore(ci): pin docker actions to the ASF-allow-listed SHAs

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -207,10 +207,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -251,10 +251,10 @@ jobs:
       TAG_NAME: ${{ needs.tags.outputs.tag_name }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -287,7 +287,7 @@ jobs:
       # across registries via the registry-to-registry mount API.
       - name: Log in to Docker Hub (release only)
         if: needs.tags.outputs.is_tag == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Why

ASF tightened the org-level GitHub Actions allow-list. The `docker/setup-buildx-action` and `docker/login-action` SHAs pinned in `publish-image.yaml` are no longer permitted, so the image-publish workflow fails before it runs:

> The actions `docker/setup-buildx-action@8d2750c…` and `docker/login-action@c94ce9f…` are not allowed in `apache/skywalking-horizon-ui` because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns …

## What

Bump both actions to the exact SHAs the main **apache/skywalking** repo pins (it passes CI under the same enterprise allow-list, so these revisions are vetted):

| action | old | new |
|---|---|---|
| `docker/setup-buildx-action` | `8d2750c…` | `d7f5e7f5…` (v4.1.0) |
| `docker/login-action` | `c94ce9f…` | `650006c6…` (v4.2.0) |

5 references updated (build job ×2, manifest job ×3). No behaviour change — same actions, allow-listed revisions.

I re-audited every third-party action across both workflows; the rest are already compliant:
- `actions/*` — created by GitHub.
- `apache/skywalking-eyes@…` — enterprise-owned.
- `pnpm/action-setup@v4` — already passing in `ci.yaml`.

## Validation

YAML-only SHA swap; structure unchanged. The publish workflow only runs on push to `main` / `v*` tags, so it'll exercise on merge.