### PR TITLE
fix(admin): per-kind save-local gate + overview validation; wrap inspect charts + step-formatted time-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ The version line is shared by every package in the monorepo (apps + shared packa
 - The **Roles & Permissions** board now lists `infra-3d:read` — the permission to view the **3D Infrastructure Map** — under the data-catalog group, with a matching "3D infrastructure map" row in the menu-visibility matrix. It was already enforced and granted to every built-in role (viewer and up), but it never appeared on the board, so an admin couldn't see who held it.
 - Editing a **layer dashboard template** is now gated on the `dashboard:write` permission the editor already advertises; publishing overview, alert, and 3D-map configs stays on `overview:write`. The required permission is resolved per template kind at save time. Built-in roles are unaffected (`operator` and `admin` hold both), but a custom role granted only `dashboard:write` can now save layer dashboards.
 - The **Cluster Status debug view** (`/api/debug/status`) now requires only `live-debug:read`. It previously also demanded `cluster:read`, so a role granted live-debug access but not cluster-read was wrongly blocked.
+- Saving a **local draft** of a template (the "Save local" action) now enforces the same per-kind permission as publishing — a layer draft needs `dashboard:write`, other kinds `overview:write` — instead of a blanket `overview:write`.
 
 ### Fixes
 
@@ -138,6 +139,7 @@ The version line is shared by every package in the monorepo (apps + shared packa
 - **Baseline security response headers** (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`) are now sent on every response.
 - Removed an internal `?mockTop=` debug query parameter that padded top-N widgets with synthetic rows; it no longer ships in release builds.
 - **The profiling pages now use more of the page height.** The Trace / eBPF / Async / pprof / network profiling layouts were sized off a viewport offset that over-counted the chrome above them, leaving dead space at the bottom on taller screens; they now extend closer to the bottom of the view.
+- **Overview dashboard templates are validated before save.** A malformed overview (missing a required field, an unknown widget type) is now rejected with a clear field-level error instead of being written to OAP — restoring a guard that was lost when overview editing moved to the OAP-backed save path.
 
 ### Documentation & release tooling
 

--- a/apps/bff/src/http/admin/overview-templates.ts
+++ b/apps/bff/src/http/admin/overview-templates.ts
@@ -101,7 +101,10 @@ const widgetSchema = z.object({
   rowSpan: z.number().int().min(1).max(12).optional(),
 });
 
-const dashboardSchema = z.object({
+/** Overview-dashboard content schema. Exported so the OAP-backed save path
+ *  (`/api/admin/templates/save`) validates the same shape this create route
+ *  does — the guard the editor relied on before the save migration. */
+export const dashboardSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   description: z.string().optional(),

--- a/apps/bff/src/http/admin/template-sync.ts
+++ b/apps/bff/src/http/admin/template-sync.ts
@@ -81,6 +81,7 @@ import type { OverviewDashboard } from '@skywalking-horizon-ui/api-client';
 import { writeOverviewDashboard } from '../../logic/overview/loader.js';
 import { getLayerOverlay, getOverviewOverlay, isLocale } from '../../i18n/index.js';
 import { validateInfra3dConfig } from '../../logic/infra-3d/validate.js';
+import { dashboardSchema } from './overview-templates.js';
 import { logger } from '../../logger.js';
 
 export interface TemplateSyncAdminDeps {
@@ -519,6 +520,23 @@ export function registerTemplateSyncAdminRoutes(
         message: `expected horizon.<overview|layer|alert>.<key>, got ${JSON.stringify(name)}`,
       });
     }
+    // Same per-kind write authority as the OAP-backed save: a layer draft
+    // needs dashboard:write, everything else overview:write.
+    const saveVerb = parsed.kind === 'layer' ? 'dashboard:write' : 'overview:write';
+    const session = req.session;
+    if (!session) {
+      return reply.code(401).send({ error: 'unauthenticated' });
+    }
+    if (!sessionHasVerb(deps.config.current, session.roles, saveVerb)) {
+      return reply.code(403).send({ error: 'permission_denied', verb: saveVerb });
+    }
+    if (parsed.kind === 'overview') {
+      const v = dashboardSchema.safeParse(content);
+      if (!v.success) {
+        const issues = v.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+        return reply.code(400).send({ code: 'invalid_content', issues });
+      }
+    }
     try {
       if (parsed.kind === 'layer') {
         writeLayerTemplate(content as Parameters<typeof writeLayerTemplate>[0]);
@@ -580,6 +598,12 @@ export function registerTemplateSyncAdminRoutes(
       const v = validateInfra3dConfig(content);
       if (!v.ok) {
         return reply.code(400).send({ code: 'invalid_content', issues: v.issues });
+      }
+    } else if (parsed.kind === 'overview') {
+      const v = dashboardSchema.safeParse(content);
+      if (!v.success) {
+        const issues = v.error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+        return reply.code(400).send({ code: 'invalid_content', issues });
       }
     }
     resync(); // fresh OAP read before deciding create-vs-update — peers / past races shouldn't leave us writing duplicates

--- a/apps/bff/src/rbac/route-policy.ts
+++ b/apps/bff/src/rbac/route-policy.ts
@@ -165,7 +165,8 @@ export const ROUTE_POLICY: Record<string, RoutePolicy> = {
   'POST /api/admin/templates/resolve-conflicts':   'overview:write',
   'POST /api/admin/templates/save-translation':    'overview:write',
   'POST /api/admin/templates/delete-translation':  'overview:write',
-  'POST /api/admin/templates/save-local':          'overview:write',
+  // `save-local` is gated 'auth'; same per-kind verb as `save` runs in the handler.
+  'POST /api/admin/templates/save-local':          'auth',
   'POST /api/admin/templates/disable':             'overview:write',
   'POST /api/admin/templates/revert-local':        'overview:write',
   'POST /api/admin/templates/:name/push-bundled':  'overview:write',

--- a/apps/ui/src/features/operate/inspect/InspectMetricChart.vue
+++ b/apps/ui/src/features/operate/inspect/InspectMetricChart.vue
@@ -24,10 +24,13 @@
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import * as echarts from 'echarts';
 import type { ExpressionResult } from '@skywalking-horizon-ui/api-client';
+import { bucketTimeLabel } from '@/utils/formatters';
 
 const props = defineProps<{
   result: ExpressionResult;
   chart: 'line' | 'bar' | 'area';
+  /** Query step — drives the time-axis label format (same as the dashboards). */
+  step: 'MINUTE' | 'HOUR' | 'DAY';
   /** Fallback series name when a result carries no labels. */
   metricName: string;
 }>();
@@ -53,12 +56,20 @@ function buildOption(): echarts.EChartsOption {
       if (v.id) xSet.add(v.id);
     }
   }
-  const xAxis = [...xSet].sort();
+  // Bucket ids are epoch-ms: sort chronologically and format each by the query
+  // step, identical to the layer-dashboard line widgets (DAY → MM-DD,
+  // HOUR → MM-DD HH:00, MINUTE → HH:MM). Series data aligns to `xIds` by index;
+  // the axis renders the parallel `xLabels`. Non-numeric ids fall back to raw.
+  const xIds = [...xSet].sort((a, b) => Number(a) - Number(b));
+  const xLabels = xIds.map((id) => {
+    const ms = Number(id);
+    return Number.isFinite(ms) ? bucketTimeLabel(props.step, ms) : id;
+  });
 
   const series: echarts.EChartsOption['series'] = props.result.results.map((r, idx) => {
     const color = PALETTE[idx % PALETTE.length];
     const byId = new Map(r.values.map((v) => [v.id ?? '', v.value]));
-    const data = xAxis.map((id) => {
+    const data = xIds.map((id) => {
       const raw = byId.get(id);
       return raw === null || raw === undefined ? null : Number.parseFloat(raw);
     });
@@ -108,7 +119,7 @@ function buildOption(): echarts.EChartsOption {
       : undefined,
     xAxis: {
       type: 'category',
-      data: xAxis,
+      data: xLabels,
       axisLine: { lineStyle: { color: '#232f39' } },
       axisLabel: { color: '#5e6c79', fontSize: 9, hideOverlap: true, fontFamily: mono },
     },

--- a/apps/ui/src/features/operate/inspect/InspectMetricChart.vue
+++ b/apps/ui/src/features/operate/inspect/InspectMetricChart.vue
@@ -1,0 +1,155 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<script setup lang="ts">
+/**
+ * One MQE-result chart on the Metrics Inspect board. Owns its ECharts
+ * instance + lifecycle so the view never instantiates ECharts directly.
+ * A ResizeObserver covers both window resize and the density toggle (which
+ * changes each card's width), so the view needs no manual resize wiring.
+ */
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import * as echarts from 'echarts';
+import type { ExpressionResult } from '@skywalking-horizon-ui/api-client';
+
+const props = defineProps<{
+  result: ExpressionResult;
+  chart: 'line' | 'bar' | 'area';
+  /** Fallback series name when a result carries no labels. */
+  metricName: string;
+}>();
+
+const host = ref<HTMLDivElement | null>(null);
+let inst: echarts.ECharts | null = null;
+let ro: ResizeObserver | null = null;
+
+const PALETTE = [
+  '#6db4d6', '#4ec9b0', '#f0b454', '#b794e4', '#ff7a90',
+  '#9ad17a', '#e29ec8', '#6c8ee0', '#d8a064', '#73d4cc',
+];
+
+function buildOption(): echarts.EChartsOption {
+  if (props.result.results.length === 0) return {};
+  const mono = 'JetBrains Mono, ui-monospace, monospace';
+  // MQE returns per-series values with an `id` field that is the time-bucket
+  // label; use it as the x-axis category, deduped across series so the axis
+  // stays consistent when one series has gaps.
+  const xSet = new Set<string>();
+  for (const r of props.result.results) {
+    for (const v of r.values) {
+      if (v.id) xSet.add(v.id);
+    }
+  }
+  const xAxis = [...xSet].sort();
+
+  const series: echarts.EChartsOption['series'] = props.result.results.map((r, idx) => {
+    const color = PALETTE[idx % PALETTE.length];
+    const byId = new Map(r.values.map((v) => [v.id ?? '', v.value]));
+    const data = xAxis.map((id) => {
+      const raw = byId.get(id);
+      return raw === null || raw === undefined ? null : Number.parseFloat(raw);
+    });
+    const name = r.metric.labels.length > 0
+      ? r.metric.labels.map((l) => `${l.key}=${l.value}`).join('·')
+      : props.metricName;
+    if (props.chart === 'bar') {
+      return { name, type: 'bar', data, itemStyle: { color }, barMaxWidth: 10 };
+    }
+    // Always render the marker — with showSymbol:false a non-null point
+    // surrounded by nulls draws nothing and the value goes invisible.
+    return {
+      name,
+      type: 'line',
+      data,
+      smooth: true,
+      showSymbol: true,
+      symbolSize: 4,
+      connectNulls: false,
+      lineStyle: { width: 1.5, color },
+      itemStyle: { color },
+      areaStyle: props.chart === 'area' ? { color, opacity: 0.14 } : undefined,
+    };
+  });
+
+  const showLegend = series.length > 1;
+  return {
+    grid: { left: 32, right: 6, top: showLegend ? 30 : 6, bottom: 18 },
+    tooltip: {
+      trigger: 'axis',
+      // Body-level so it isn't clipped by the card overflow or the sidebar.
+      appendToBody: true,
+      backgroundColor: '#1c2630',
+      borderWidth: 0,
+      textStyle: { color: '#e6edf3', fontSize: 10.5, fontFamily: mono },
+    },
+    legend: showLegend
+      ? {
+          top: 0, left: 0, right: 0, type: 'scroll',
+          textStyle: { color: '#c2cbd4', fontSize: 11, fontFamily: mono },
+          itemHeight: 8, itemWidth: 14, itemGap: 16,
+          pageIconColor: '#c2cbd4',
+          pageIconInactiveColor: '#3a4651',
+          pageIconSize: 11,
+          pageTextStyle: { color: '#8a96a3', fontSize: 10 },
+        }
+      : undefined,
+    xAxis: {
+      type: 'category',
+      data: xAxis,
+      axisLine: { lineStyle: { color: '#232f39' } },
+      axisLabel: { color: '#5e6c79', fontSize: 9, hideOverlap: true, fontFamily: mono },
+    },
+    yAxis: {
+      type: 'value',
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: '#1c2630' } },
+      axisLabel: { color: '#5e6c79', fontSize: 9, fontFamily: mono },
+    },
+    series,
+    animationDuration: 250,
+  };
+}
+
+function render() {
+  inst?.setOption(buildOption(), true);
+}
+
+onMounted(() => {
+  if (!host.value) return;
+  inst = echarts.init(host.value, undefined, { renderer: 'canvas' });
+  render();
+  ro = new ResizeObserver(() => inst?.resize());
+  ro.observe(host.value);
+});
+
+watch([() => props.result, () => props.chart], render);
+
+onBeforeUnmount(() => {
+  ro?.disconnect();
+  inst?.dispose();
+  inst = null;
+  ro = null;
+});
+</script>
+
+<template>
+  <div ref="host" class="inspect-chart" />
+</template>
+
+<style scoped>
+.inspect-chart { width: 100%; height: var(--chart-h, 150px); }
+</style>

--- a/apps/ui/src/features/operate/inspect/InspectView.vue
+++ b/apps/ui/src/features/operate/inspect/InspectView.vue
@@ -1286,6 +1286,7 @@ function scopeShort(scope: InspectScope): string {
               v-else-if="w.selectedIds.size > 0 && w.result && w.result.results.length > 0"
               :result="w.result"
               :chart="w.chart"
+              :step="step"
               :metric-name="w.metric.name"
             />
             <div v-else class="card__empty">

--- a/apps/ui/src/features/operate/inspect/InspectView.vue
+++ b/apps/ui/src/features/operate/inspect/InspectView.vue
@@ -33,10 +33,10 @@
  * vue-query key AND passes `refresh=true` to the catalog + mqe-target
  * endpoints so the BFF rebuilds its attribution / dump caches.
  */
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch, watchEffect } from 'vue';
+import { computed, reactive, ref, watch, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
-import * as echarts from 'echarts';
+import InspectMetricChart from './InspectMetricChart.vue';
 import {
   INSPECT_STEPS,
   type EntitiesResponse,
@@ -975,168 +975,6 @@ async function refreshEverything() {
   );
 }
 
-// ─── ECharts wiring ────────────────────────────────────────────────
-
-const chartHosts = ref<Record<string, HTMLDivElement | null>>({});
-const chartInstances = new Map<string, echarts.ECharts>();
-
-function setChartHost(id: string, el: HTMLDivElement | null) {
-  /* When the chart container unmounts (loading / error state took
-   * over via v-else-if), the echarts instance is still bound to the
-   * now-removed DOM element. Dispose it here so the next mount gets
-   * a fresh instance bound to the new node — otherwise `setOption`
-   * lands on a detached canvas and the chart silently goes dark. */
-  if (el === null) {
-    const old = chartInstances.get(id);
-    if (old) {
-      old.dispose();
-      chartInstances.delete(id);
-    }
-  }
-  chartHosts.value[id] = el;
-}
-
-const PALETTE = [
-  '#6db4d6', '#4ec9b0', '#f0b454', '#b794e4', '#ff7a90',
-  '#9ad17a', '#e29ec8', '#6c8ee0', '#d8a064', '#73d4cc',
-];
-
-function buildOption(w: Widget): echarts.EChartsOption {
-  if (!w.result || w.result.results.length === 0) return {};
-  const mono = 'JetBrains Mono, ui-monospace, monospace';
-  /* MQE returns per-series values with an `id` field that is the
-   * time-bucket label; use it as the x-axis category. We dedupe ids
-   * across series so the axis is consistent when one series has
-   * gaps. */
-  const xSet = new Set<string>();
-  for (const r of w.result.results) {
-    for (const v of r.values) {
-      if (v.id) xSet.add(v.id);
-    }
-  }
-  const xAxis = [...xSet].sort();
-
-  const series: echarts.EChartsOption['series'] = w.result.results.map((r, idx) => {
-    const color = PALETTE[idx % PALETTE.length];
-    const byId = new Map(r.values.map((v) => [v.id ?? '', v.value]));
-    const data = xAxis.map((id) => {
-      const raw = byId.get(id);
-      return raw === null || raw === undefined ? null : Number.parseFloat(raw);
-    });
-    const name = r.metric.labels.length > 0
-      ? r.metric.labels.map((l) => `${l.key}=${l.value}`).join('·')
-      : (w.metric.name);
-    if (w.chart === 'bar') {
-      return { name, type: 'bar', data, itemStyle: { color }, barMaxWidth: 10 };
-    }
-    /* Always render the marker. With `showSymbol: false` a single
-     * non-null point (or any non-null surrounded by nulls) draws
-     * nothing — the line has no segment, no dot, the value goes
-     * invisible. Small symbol keeps dense series readable while the
-     * sparse case still surfaces every value. */
-    return {
-      name,
-      type: 'line',
-      data,
-      smooth: true,
-      showSymbol: true,
-      symbolSize: 4,
-      connectNulls: false,
-      lineStyle: { width: 1.5, color },
-      itemStyle: { color },
-      areaStyle: w.chart === 'area' ? { color, opacity: 0.14 } : undefined,
-    };
-  });
-
-  const showLegend = series.length > 1;
-  return {
-    grid: { left: 32, right: 6, top: showLegend ? 30 : 6, bottom: 18 },
-    tooltip: {
-      trigger: 'axis',
-      // Body-level so it isn't clipped by the card overflow or the sidebar.
-      appendToBody: true,
-      backgroundColor: '#1c2630',
-      borderWidth: 0,
-      textStyle: { color: '#e6edf3', fontSize: 10.5, fontFamily: mono },
-    },
-    legend: showLegend
-      ? {
-          top: 0, left: 0, right: 0, type: 'scroll',
-          textStyle: { color: '#c2cbd4', fontSize: 11, fontFamily: mono },
-          itemHeight: 8, itemWidth: 14, itemGap: 16,
-          // Active page direction bright; the unavailable one (e.g. the
-          // left arrow on page 1) clearly dim so it doesn't read as
-          // clickable.
-          pageIconColor: '#c2cbd4',
-          pageIconInactiveColor: '#3a4651',
-          pageIconSize: 11,
-          pageTextStyle: { color: '#8a96a3', fontSize: 10 },
-        }
-      : undefined,
-    xAxis: {
-      type: 'category',
-      data: xAxis,
-      axisLine: { lineStyle: { color: '#232f39' } },
-      axisLabel: { color: '#5e6c79', fontSize: 9, hideOverlap: true, fontFamily: mono },
-    },
-    yAxis: {
-      type: 'value',
-      axisLine: { show: false },
-      axisTick: { show: false },
-      splitLine: { lineStyle: { color: '#1c2630' } },
-      axisLabel: { color: '#5e6c79', fontSize: 9, fontFamily: mono },
-    },
-    series,
-    animationDuration: 250,
-  };
-}
-
-function renderWidget(w: Widget) {
-  const host = chartHosts.value[w.id];
-  if (!host) return;
-  let inst = chartInstances.get(w.id);
-  if (!inst) {
-    inst = echarts.init(host, undefined, { renderer: 'canvas' });
-    chartInstances.set(w.id, inst);
-  }
-  inst.setOption(buildOption(w), true);
-}
-function renderAll() {
-  for (const w of widgets.value) renderWidget(w);
-}
-function resizeAll() {
-  for (const inst of chartInstances.values()) inst.resize();
-}
-
-watch(widgets, async () => {
-  await nextTick();
-  renderAll();
-  const live = new Set(widgets.value.map((w) => w.id));
-  for (const [id, inst] of chartInstances) {
-    if (!live.has(id)) {
-      inst.dispose();
-      chartInstances.delete(id);
-    }
-  }
-}, { deep: true });
-
-watch(density, async () => {
-  await nextTick();
-  resizeAll();
-  renderAll();
-});
-
-onMounted(async () => {
-  await nextTick();
-  renderAll();
-  window.addEventListener('resize', resizeAll);
-});
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', resizeAll);
-  for (const inst of chartInstances.values()) inst.dispose();
-  chartInstances.clear();
-});
-
 // ─── Display helpers ───────────────────────────────────────────────
 
 function sourcePillTone(s: Source): 'ok' | 'warn' | 'err' | 'dim' {
@@ -1444,10 +1282,11 @@ function scopeShort(scope: InspectScope): string {
             <div v-else-if="w.error" class="card__empty card__empty--err">
               <div class="card__empty-text">{{ w.error }}</div>
             </div>
-            <div
+            <InspectMetricChart
               v-else-if="w.selectedIds.size > 0 && w.result && w.result.results.length > 0"
-              :ref="(el) => setChartHost(w.id, el as HTMLDivElement)"
-              class="card__chart"
+              :result="w.result"
+              :chart="w.chart"
+              :metric-name="w.metric.name"
             />
             <div v-else class="card__empty">
               <div class="card__empty-icon">∅</div>
@@ -1918,7 +1757,6 @@ function scopeShort(scope: InspectScope): string {
 .link:hover { text-decoration: underline; }
 
 .card__chartwrap { min-height: var(--chart-h, 150px); position: relative; }
-.card__chart { width: 100%; height: var(--chart-h, 150px); }
 .card__empty {
   height: var(--chart-h, 150px);
   display: flex;

--- a/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
+++ b/apps/ui/src/render/layer-dashboard/LayerDashboardsView.vue
@@ -41,7 +41,7 @@ import { useLayerEndpoints } from '@/layer/useLayerEndpoints';
 import { useLayerInstances } from '@/layer/useLayerInstances';
 import { useLayerServices } from '@/layer/useLayerServices';
 import { useLayerLanding } from '@/layer/useLayerLanding';
-import { useTimeRangeStore, type TimeStep } from '@/controls/timeRange';
+import { useTimeRangeStore } from '@/controls/timeRange';
 import { pushEvent } from '@/controls/eventLog';
 import { useLayers } from '@/shell/useLayers';
 import { useSelectedEndpoint } from '@/layer/useSelectedEndpoint';
@@ -49,7 +49,7 @@ import { useSelectedInstance } from '@/layer/useSelectedInstance';
 import { useSelectedService } from '@/layer/useSelectedService';
 import { useLayerServiceName } from '@/layer/useLayerServiceName';
 import { useSetupStore } from '@/state/setup';
-import { fmtMetricAs, type MetricFormat } from '@/utils/formatters';
+import { bucketTimeLabel, fmtMetricAs, type MetricFormat } from '@/utils/formatters';
 import { ref, watch, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { FF_ENTITY_COMPARE } from '@/utils/featureFlags';
@@ -140,20 +140,13 @@ const rangeRef = computed(() => {
 // the active window + step — the buckets are uniform, so spacing N points
 // across [start, end] matches OAP's bucketing. Formatted browser-local
 // (the app displays browser-local; ECharts handles ms→local elsewhere).
-function fmtBucket(step: TimeStep, ms: number): string {
-  const d = new Date(ms);
-  const z = (n: number) => String(n).padStart(2, '0');
-  if (step === 'DAY') return `${z(d.getMonth() + 1)}-${z(d.getDate())}`;
-  if (step === 'HOUR') return `${z(d.getMonth() + 1)}-${z(d.getDate())} ${z(d.getHours())}:00`;
-  return `${z(d.getHours())}:${z(d.getMinutes())}`;
-}
 function xLabelsForLen(len: number): string[] {
   if (len <= 0) return [];
   const { startMs, endMs } = timeRange.range;
   const step = timeRange.step;
-  if (len === 1) return [fmtBucket(step, endMs)];
+  if (len === 1) return [bucketTimeLabel(step, endMs)];
   return Array.from({ length: len }, (_, i) =>
-    fmtBucket(step, startMs + ((endMs - startMs) * i) / (len - 1)),
+    bucketTimeLabel(step, startMs + ((endMs - startMs) * i) / (len - 1)),
   );
 }
 const landing = useLayerLanding(safeLayer, safeCfg, rangeRef);

--- a/apps/ui/src/utils/formatters.ts
+++ b/apps/ui/src/utils/formatters.ts
@@ -16,6 +16,20 @@
  */
 
 /**
+ * Time-axis label for a metric bucket at epoch-ms `ms`, formatted browser-local
+ * for the query `step`. Shared by the layer-dashboard line widgets and the
+ * Metrics Inspect board so both read identically:
+ * DAY → `MM-DD`, HOUR → `MM-DD HH:00`, MINUTE → `HH:MM`.
+ */
+export function bucketTimeLabel(step: 'MINUTE' | 'HOUR' | 'DAY', ms: number): string {
+  const d = new Date(ms);
+  const z = (n: number) => String(n).padStart(2, '0');
+  if (step === 'DAY') return `${z(d.getMonth() + 1)}-${z(d.getDate())}`;
+  if (step === 'HOUR') return `${z(d.getMonth() + 1)}-${z(d.getDate())} ${z(d.getHours())}:00`;
+  return `${z(d.getHours())}:${z(d.getMinutes())}`;
+}
+
+/**
  * Compact-readable formatter for landing-card numeric cells.
  *
  * Rules:


### PR DESCRIPTION
Three RC0-review follow-ups: the per-kind template-save validation/gate consistency (§4.5), the InspectView "charts must be wrapped" cleanup, and a time-axis formatting fix that fell out of it.

## What

**§4.5 — save validation + gate consistency (BFF)** · `028950d`
- `/api/admin/templates/save-local` was gated wholesale on `overview:write`. It now enforces the **same per-kind verb** as the OAP-backed save — `layer → dashboard:write`, else `overview:write` — in the handler (route gated `auth`), so a `dashboard:write`-only role can save layer drafts.
- **Overview content is now validated before any write.** The `dashboardSchema` guard the legacy overview-create route ran was lost when editing moved to `/templates/save`; a malformed overview (missing required field, unknown widget type) is now rejected with a field-level error on **both** save paths instead of being written to OAP. `dashboardSchema` is exported for reuse.

**InspectView — wrap the board charts (UI)** · `38b550e`
- The view instantiated ECharts directly (violating "charts are wrapped"). The shared `TimeChart` is line/area-only but the inspect board also has a **bar** mode, so I extracted a feature-local `InspectMetricChart.vue` that owns one ECharts instance + lifecycle. A `ResizeObserver` replaces the manual window-resize + density-watch wiring, and Vue's per-widget mount/unmount replaces the manual instance `Map` + disposal. The chart-option builder moved **verbatim** — behavior unchanged. Net **−160 lines** in the view.

**Inspect time-axis format (UI)** · `aa48ede`
- The inspect charts showed raw epoch-ms on the x-axis and tooltip header. They now format each bucket by the **query step**, identical to the layer-dashboard line widgets: `DAY → MM-DD`, `HOUR → MM-DD HH:00`, `MINUTE → HH:MM` (browser-local). The per-step formatter is extracted to a shared `bucketTimeLabel` in `utils/formatters` and used by **both** the dashboard widgets and the inspect chart, so they can't drift.

## Validation

- `pnpm -r type-check`, `build` (UI + BFF), `license:check` (0 invalid), `pnpm -r lint`, `pnpm -r test:unit` (UI 116 + BFF 116) — all green.
- **§4.5 live against the demo OAP** (safe, no-write paths only): `viewer` → `/save-local` returns **403** with the correct per-kind verb (gate active, nothing written); an invalid overview returns **400 `invalid_content`** with field-level issues on both `/save-local` and `/templates/save`; a real bundled overview (`services`, 11 widgets) matches the schema, so valid saves still pass.
- **InspectView visually confirmed** on the running dev env: charts render, the tooltip works, the line/bar/area toggle works, and the time-axis reads correctly across the `last 10m / 5h / 2d` presets (MINUTE/HOUR/DAY). The chart refactor is behavior-preserving (option builder moved verbatim).