### PR TITLE
Release 0.7.0, bump to 1.0.0-dev-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to Apache SkyWalking Horizon UI, written from the operator's poi
 
 The version line is shared by every package in the monorepo (apps + shared packages) plus the BFF's `HORIZON_VERSION` default.
 
+## 1.0.0-dev
+
+(In development — fill in highlights here before cutting the release.)
+
 ## 0.7.0
 
 ### Browser errors & source maps

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -334,7 +334,7 @@ if (staticDir && existsSync(staticDir)) {
 // admin status pages.
 app.get('/api/health', async () => ({
   status: 'ok',
-  version: process.env.HORIZON_VERSION ?? '0.7.0-dev',
+  version: process.env.HORIZON_VERSION ?? '0.7.0',
 }));
 
 const { host, port } = source.current.server;

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -334,7 +334,7 @@ if (staticDir && existsSync(staticDir)) {
 // admin status pages.
 app.get('/api/health', async () => ({
   status: 'ok',
-  version: process.env.HORIZON_VERSION ?? '0.7.0',
+  version: process.env.HORIZON_VERSION ?? '1.0.0-dev-dev',
 }));
 
 const { host, port } = source.current.server;

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/setup/container-image.md
+++ b/docs/setup/container-image.md
@@ -15,7 +15,7 @@ Registry: **GitHub Container Registry (GHCR)** at `ghcr.io/apache/skywalking-hor
 | `main` | Head of `main`. Moves on every merge. | Smoke-test the development branch. |
 
 ```sh
-docker pull ghcr.io/apache/skywalking-horizon-ui:0.6.0
+docker pull ghcr.io/apache/skywalking-horizon-ui:0.7.0
 docker pull ghcr.io/apache/skywalking-horizon-ui:<sha>
 ```
 
@@ -67,7 +67,7 @@ docker run -d \
   --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
-  ghcr.io/apache/skywalking-horizon-ui:0.6.0
+  ghcr.io/apache/skywalking-horizon-ui:0.7.0
 ```
 
 Notes:
@@ -80,7 +80,7 @@ Notes:
 For immutable single-tenant deployments, build a child image that includes your config:
 
 ```dockerfile
-FROM ghcr.io/apache/skywalking-horizon-ui:0.6.0
+FROM ghcr.io/apache/skywalking-horizon-ui:0.7.0
 COPY horizon.yaml /app/horizon.yaml
 ```
 
@@ -148,7 +148,7 @@ spec:
         fsGroup: 101
       containers:
         - name: horizon
-          image: ghcr.io/apache/skywalking-horizon-ui:0.6.0
+          image: ghcr.io/apache/skywalking-horizon-ui:0.7.0
           ports:
             - containerPort: 8081
           envFrom:
@@ -190,7 +190,7 @@ docker run -d --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
   -v horizon-state:/data \
-  ghcr.io/apache/skywalking-horizon-ui:0.6.0
+  ghcr.io/apache/skywalking-horizon-ui:0.7.0
 ```
 
 Without a mounted volume the writes still land in the container's writable layer at `/data/` (ephemeral, but at least non-failing). Mounting a volume is what makes them durable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/templates",
-  "version": "0.7.0-dev",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/templates",
-  "version": "0.7.0",
+  "version": "1.0.0-dev-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release branch for 0.7.0. Two commits:

1. `Prepare release 0.7.0` — strips `-dev` from every package
   marker + `apps/bff/src/server.ts`; advances container-image docs to
   `0.7.0`. Tagged `v0.7.0` (the release-candidate commit the
   vote runs against).
2. `Prepare next release 1.0.0-dev-dev` — bumps every marker to
   `1.0.0-dev-dev` and rotates CHANGELOG for the next cycle.

Merge after the [VOTE] passes so `main` returns to a `-dev`
version with the release in its history. The `v0.7.0` tag is immutable and
keeps pointing at commit 1 regardless of how this PR is merged.