### PR TITLE
fix: correct malformed next-dev version + validate versions in release.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to Apache SkyWalking Horizon UI, written from the operator's poi
 
 The version line is shared by every package in the monorepo (apps + shared packages) plus the BFF's `HORIZON_VERSION` default.
 
-## 1.0.0-dev
+## 1.0.0
 
 (In development — fill in highlights here before cutting the release.)
 

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -334,7 +334,7 @@ if (staticDir && existsSync(staticDir)) {
 // admin status pages.
 app.get('/api/health', async () => ({
   status: 'ok',
-  version: process.env.HORIZON_VERSION ?? '1.0.0-dev-dev',
+  version: process.env.HORIZON_VERSION ?? '1.0.0-dev',
 }));
 
 const { host, port } = source.current.server;

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/templates",
-  "version": "1.0.0-dev-dev",
+  "version": "1.0.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -143,6 +143,22 @@ if ! confirm "Are these correct?"; then
     read -r -p "Enter release version: " RELEASE_VERSION
     read -r -p "Enter next version (without -dev suffix): " NEXT_RELEASE_VERSION
 fi
+
+# Normalize + validate both versions. The "next version" prompt asks for a
+# BARE X.Y.Z — the script appends `-dev` itself (Step 15) — so strip a stray
+# leading `v` / `-dev` / `-SNAPSHOT` an operator may have typed anyway, then
+# reject anything that isn't a clean semver core. Without this, entering
+# "1.0.0-dev" at the prompt silently produces the malformed "1.0.0-dev-dev".
+for _var in RELEASE_VERSION NEXT_RELEASE_VERSION; do
+    _val="${!_var}"
+    _val="${_val#v}"; _val="${_val%-dev}"; _val="${_val%-SNAPSHOT}"
+    if [[ ! "${_val}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        err "${_var} '${!_var}' is not a clean version — enter a bare X.Y.Z (e.g. 1.0.0), without a -dev suffix."
+        exit 1
+    fi
+    printf -v "${_var}" '%s' "${_val}"
+done
+
 TAG="v${RELEASE_VERSION}"
 
 # ========================== Step 4: Version-consistency check ==========================


### PR DESCRIPTION
## Why

The 0.7.0 release (#67) left `main` on a malformed next-dev version: **`1.0.0-dev-dev`**.

`scripts/release.sh` prompts for the *next version* **without** the `-dev` suffix and appends `-dev` itself. The run answered it with `1.0.0-dev`, so the suffix doubled — across all six `package.json` markers + `apps/bff/src/server.ts`, plus a `## 1.0.0-dev` CHANGELOG heading.

## What

**Fix the version** — `main` back on a clean dev version:
- six `package.json` + `apps/bff/src/server.ts`: `1.0.0-dev-dev` → **`1.0.0-dev`** (the intended next version — the run deliberately chose 1.0.0 over the 0.8.0 default).
- CHANGELOG heading: `## 1.0.0-dev` → **`## 1.0.0`**.

**Prevent recurrence** — `scripts/release.sh`:
- After the version prompts, normalize a stray leading `v` / `-dev` / `-SNAPSHOT`, then **reject anything that isn't a clean `X.Y.Z`**. Entering `1.0.0-dev` now resolves to `1.0.0` instead of silently doubling the suffix; `1.0` / `garbage` are rejected outright.

## Not affected

The **`v0.7.0` release tag is clean** — markers are `0.7.0` (verified), it points at `Prepare release 0.7.0`, and is correctly not an ancestor of `main`.