### PR TITLE
fix(templates): single-value metrics render as cards, not flat lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The version line is shared by every package in the monorepo (apps + shared packa
 - **Shareable trace links are unified.** Native and Zipkin traces both open from a single `?traceId=` link under the layer's trace tab; the viewer auto-selects native vs Zipkin by the trace-ID shape, so `/layer/<layer>/trace?traceId=…` always opens the right one.
 - **Trace filters are searchable, on-theme dropdowns.** The native Service / Instance / Endpoint pickers and the Zipkin Service / Remote service / Span name pickers use a dark type-to-filter dropdown that reopens correctly after a pick.
 
+### Bundled layer dashboards
+
+- **Single-value metrics now render as cards, not flat lines, on several layer dashboards.** Widgets whose expression collapses the window to one number (a `latest(...)` total) had been mis-ported as line charts — drawn as a lone dot that misreads as a time series and shares one axis with an unrelated average trend. Each is now split into a proper single-value **card** (the total) plus a trend **line** (the average), matching the metric's shape, the way booster-ui rendered them. Affects the **Virtual GenAI** (Input / Output Tokens, Estimated Cost — provider and model scopes), **Elasticsearch** (deleted documents), **ClickHouse** (Zookeeper sessions / watches), **RabbitMQ** (connection / publisher / consumer / channel / queue totals, allocated memory), **RocketMQ** (max CommitLog disk ratio, max producer / consumer message size), and **APISIX** (etcd reachability) dashboards; every changed dashboard row still tiles to full width.
+
 ## 0.7.0
 
 ### Browser errors & source maps

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.de.json
@@ -113,14 +113,18 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd erreichbar",
         "expressions": [
-          null,
+          null
+        ]
+      },
+      {
+        "title": "etcd Indizes",
+        "expressions": [
           null
         ],
         "expressionLabels": [
-          "indizes",
-          "erreichbar"
+          "indizes"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.es.json
@@ -75,10 +75,12 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd accesible"
+      },
+      {
+        "title": "etcd índices",
         "expressionLabels": [
-          "índices",
-          "accesible"
+          "índices"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.fr.json
@@ -70,10 +70,12 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd joignable"
+      },
+      {
+        "title": "etcd index",
         "expressionLabels": [
-          "index",
-          "joignable"
+          "index"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.ja.json
@@ -70,10 +70,12 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd 到達可能"
+      },
+      {
+        "title": "etcd インデックス",
         "expressionLabels": [
-          "インデックス",
-          "到達可能"
+          "インデックス"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.ko.json
@@ -70,10 +70,12 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd 도달 가능"
+      },
+      {
+        "title": "etcd 인덱스",
         "expressionLabels": [
-          "인덱스",
-          "도달 가능"
+          "인덱스"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.pt.json
@@ -75,10 +75,12 @@
         ]
       },
       {
-        "title": "etcd",
+        "title": "etcd acessível"
+      },
+      {
+        "title": "etcd índices",
         "expressionLabels": [
-          "índices",
-          "acessível"
+          "índices"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/apisix.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.i18n.zh-CN.json
@@ -36,8 +36,11 @@
         "expressionLabels": ["capacity", "free"]
       },
       {
-        "title": "etcd",
-        "expressionLabels": ["indexes", "reachable"]
+        "title": "etcd 可达"
+      },
+      {
+        "title": "etcd 索引",
+        "expressionLabels": ["indexes"]
       },
       {
         "title": "未匹配流量",

--- a/apps/bff/src/bundled_templates/layers/apisix.json
+++ b/apps/bff/src/bundled_templates/layers/apisix.json
@@ -205,18 +205,27 @@
         "rowSpan": 2
       },
       {
-        "id": "etcd",
-        "title": "etcd",
-        "type": "line",
+        "id": "etcd_total",
+        "title": "etcd Reachable",
+        "tip": "0 represents etcd unreachable, 1 represents etcd connected.",
+        "type": "card",
         "expressions": [
-          "meter_apisix_instance_etcd_indexes",
           "latest(meter_apisix_instance_etcd_reachable)"
         ],
-        "expressionLabels": [
-          "indexes",
-          "reachable"
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "etcd",
+        "title": "etcd Indexes",
+        "type": "line",
+        "expressions": [
+          "meter_apisix_instance_etcd_indexes"
         ],
-        "span": 6,
+        "expressionLabels": [
+          "indexes"
+        ],
+        "span": 3,
         "rowSpan": 2
       },
       {

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.de.json
@@ -129,18 +129,26 @@
         ]
       },
       {
-        "title": "Zookeeper-Aktivität",
+        "title": "Zookeeper Bytes (b/s)",
         "expressions": [
-          null,
-          null,
           null,
           null
         ],
         "expressionLabels": [
-          "sitzungen",
-          "watches",
           "bytes ges.",
           "bytes empf."
+        ]
+      },
+      {
+        "title": "Zookeeper-Sessions",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Zookeeper Watches",
+        "expressions": [
+          null
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.es.json
@@ -143,13 +143,17 @@
         ]
       },
       {
-        "title": "Actividad de Zookeeper",
+        "title": "Zookeeper Bytes (b/s)",
         "expressionLabels": [
-          "sesiones",
-          "watches",
           "bytes enviados",
           "bytes recibidos"
         ]
+      },
+      {
+        "title": "Sesiones de Zookeeper"
+      },
+      {
+        "title": "Zookeeper Watches"
       },
       {
         "title": "Conexiones keeper vivas"

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.fr.json
@@ -83,13 +83,17 @@
         ]
       },
       {
-        "title": "Activité Zookeeper",
+        "title": "Zookeeper Bytes (b/s)",
         "expressionLabels": [
-          "sessions",
-          "watches",
           "octets envoyés",
           "octets reçus"
         ]
+      },
+      {
+        "title": "Sessions Zookeeper"
+      },
+      {
+        "title": "Zookeeper Watches"
       },
       {
         "title": "Connexions Keeper actives"

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.ja.json
@@ -83,13 +83,17 @@
         ]
       },
       {
-        "title": "Zookeeper アクティビティ",
+        "title": "Zookeeper バイト (b/s)",
         "expressionLabels": [
-          "セッション",
-          "watch",
           "送信バイト",
           "受信バイト"
         ]
+      },
+      {
+        "title": "Zookeeper セッション"
+      },
+      {
+        "title": "Zookeeper Watch"
       },
       {
         "title": "Keeper Alive 接続"

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.ko.json
@@ -83,13 +83,17 @@
         ]
       },
       {
-        "title": "Zookeeper 활동",
+        "title": "Zookeeper 바이트 (b/s)",
         "expressionLabels": [
-          "세션",
-          "watch",
           "전송 바이트",
           "수신 바이트"
         ]
+      },
+      {
+        "title": "Zookeeper 세션"
+      },
+      {
+        "title": "Zookeeper Watches"
       },
       {
         "title": "Keeper 활성 연결"

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.pt.json
@@ -87,13 +87,17 @@
         ]
       },
       {
-        "title": "Atividade do Zookeeper",
+        "title": "Zookeeper Bytes (b/s)",
         "expressionLabels": [
-          "sessões",
-          "watches",
           "bytes enviados",
           "bytes recebidos"
         ]
+      },
+      {
+        "title": "Sessões do Zookeeper"
+      },
+      {
+        "title": "Zookeeper Watches"
       },
       {
         "title": "Conexões ativas do Keeper"

--- a/apps/bff/src/bundled_templates/layers/clickhouse.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.i18n.zh-CN.json
@@ -45,9 +45,11 @@
         "expressionLabels": ["fetch", "send"]
       },
       {
-        "title": "Zookeeper 活动",
-        "expressionLabels": ["sessions", "watches", "bytes sent", "bytes recv"]
+        "title": "Zookeeper 字节 (b/s)",
+        "expressionLabels": ["bytes sent", "bytes recv"]
       },
+      { "title": "Zookeeper 会话" },
+      { "title": "Zookeeper Watches" },
       { "title": "Keeper 活跃连接" },
       { "title": "Keeper 未完成请求" }
     ],

--- a/apps/bff/src/bundled_templates/layers/clickhouse.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.json
@@ -55,7 +55,7 @@
           "latest(aggregate_labels(meter_clickhouse_file_open,sum))"
         ],
         "span": 3,
-        "rowSpan": 1
+        "rowSpan": 2
       },
       {
         "id": "qps",
@@ -270,7 +270,7 @@
           "latest(meter_clickhouse_instance_uptime)/3600/24"
         ],
         "span": 3,
-        "rowSpan": 1
+        "rowSpan": 2
       },
       {
         "id": "version",
@@ -280,7 +280,7 @@
           "latest(meter_clickhouse_instance_version)"
         ],
         "span": 3,
-        "rowSpan": 1
+        "rowSpan": 2
       },
       {
         "id": "cpu",
@@ -426,7 +426,7 @@
           "latest(meter_clickhouse_instance_file_open)"
         ],
         "span": 4,
-        "rowSpan": 1
+        "rowSpan": 2
       },
       {
         "id": "insert_io",

--- a/apps/bff/src/bundled_templates/layers/clickhouse.json
+++ b/apps/bff/src/bundled_templates/layers/clickhouse.json
@@ -203,22 +203,40 @@
       },
       {
         "id": "zk",
-        "title": "Zookeeper Activity",
+        "title": "Zookeeper Bytes (b/s)",
         "type": "line",
         "expressions": [
-          "latest(aggregate_labels(meter_clickhouse_zookeeper_session,sum))",
-          "latest(aggregate_labels(meter_clickhouse_zookeeper_watch,sum))",
           "aggregate_labels(meter_clickhouse_zookeeper_bytes_sent,sum)",
           "aggregate_labels(meter_clickhouse_zookeeper_bytes_received,sum)"
         ],
         "expressionLabels": [
-          "sessions",
-          "watches",
           "bytes sent",
           "bytes recv"
         ],
         "span": 6,
         "rowSpan": 2
+      },
+      {
+        "id": "zk_sessions",
+        "title": "Zookeeper Sessions",
+        "type": "card",
+        "expressions": [
+          "latest(aggregate_labels(meter_clickhouse_zookeeper_session,sum))"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
+        "id": "zk_watches",
+        "title": "Zookeeper Watches",
+        "type": "card",
+        "expressions": [
+          "latest(aggregate_labels(meter_clickhouse_zookeeper_watch,sum))"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
       },
       {
         "id": "keeper_alive",

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.de.json
@@ -266,16 +266,20 @@
         ]
       },
       {
+        "title": "Gelöschte Dokumente",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "Dokumente",
         "expressions": [
-          null,
           null,
           null
         ],
         "expressionLabels": [
           "alle",
-          "primary",
-          "gelöscht"
+          "primary"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.es.json
@@ -153,11 +153,13 @@
         "title": "Tamaño del índice (primario)"
       },
       {
+        "title": "Documentos eliminados"
+      },
+      {
         "title": "Documentos",
         "expressionLabels": [
           "todos",
-          "primario",
-          "eliminados"
+          "primario"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.fr.json
@@ -154,11 +154,13 @@
         "title": "Taille d'index (primaires)"
       },
       {
+        "title": "Documents supprimés"
+      },
+      {
         "title": "Documents",
         "expressionLabels": [
           "tous",
-          "primaire",
-          "supprimés"
+          "primaire"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.ja.json
@@ -154,11 +154,13 @@
         "title": "インデックスサイズ (primary)"
       },
       {
+        "title": "削除済みドキュメント"
+      },
+      {
         "title": "ドキュメント",
         "expressionLabels": [
           "全件",
-          "primary",
-          "削除"
+          "primary"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.ko.json
@@ -154,11 +154,13 @@
         "title": "인덱스 크기 (primary)"
       },
       {
+        "title": "삭제된 문서"
+      },
+      {
         "title": "문서",
         "expressionLabels": [
           "전체",
-          "primary",
-          "deleted"
+          "primary"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.pt.json
@@ -159,11 +159,13 @@
         "title": "Tamanho do índice (primário)"
       },
       {
+        "title": "Documentos removidos"
+      },
+      {
         "title": "Documentos",
         "expressionLabels": [
           "todos",
-          "primário",
-          "removidos"
+          "primário"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.i18n.zh-CN.json
@@ -81,9 +81,10 @@
       },
       { "title": "索引大小（全部分片）" },
       { "title": "索引大小（主分片）" },
+      { "title": "已删除文档" },
       {
         "title": "文档数",
-        "expressionLabels": ["all", "primary", "deleted"]
+        "expressionLabels": ["all", "primary"]
       },
       {
         "title": "每请求平均搜索耗时（s）",

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.json
@@ -90,7 +90,7 @@
         "expressions": [
           "latest(meter_elasticsearch_cluster_primary_shards_total)"
         ],
-        "span": 3,
+        "span": 4,
         "rowSpan": 1
       },
       {
@@ -155,7 +155,7 @@
         "expressions": [
           "latest(meter_elasticsearch_cluster_breakers_tripped)"
         ],
-        "span": 3,
+        "span": 4,
         "rowSpan": 1
       },
       {
@@ -166,7 +166,7 @@
         "expressions": [
           "avg(meter_elasticsearch_cluster_cpu_usage_avg)"
         ],
-        "span": 3,
+        "span": 4,
         "rowSpan": 1
       },
       {
@@ -361,7 +361,7 @@
           "avg(meter_elasticsearch_node_open_file_count)"
         ],
         "span": 6,
-        "rowSpan": 1
+        "rowSpan": 2
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/elasticsearch.json
+++ b/apps/bff/src/bundled_templates/layers/elasticsearch.json
@@ -402,7 +402,7 @@
         "expressions": [
           "latest(meter_elasticsearch_index_indices_store_size_bytes_total)/1024/1024/1024"
         ],
-        "span": 3,
+        "span": 4,
         "rowSpan": 1,
         "format": "decimal",
         "unit": "GB"
@@ -414,10 +414,20 @@
         "expressions": [
           "latest(meter_elasticsearch_index_indices_store_size_bytes_primary)/1024/1024/1024"
         ],
-        "span": 3,
+        "span": 4,
         "rowSpan": 1,
         "format": "decimal",
         "unit": "GB"
+      },
+      {
+        "id": "docs_total",
+        "title": "Deleted Documents",
+        "type": "card",
+        "expressions": [
+          "latest(meter_elasticsearch_index_indices_deleted_docs_primary)"
+        ],
+        "span": 4,
+        "rowSpan": 1
       },
       {
         "id": "docs",
@@ -425,15 +435,13 @@
         "type": "line",
         "expressions": [
           "meter_elasticsearch_index_indices_docs_total",
-          "meter_elasticsearch_index_indices_docs_primary",
-          "latest(meter_elasticsearch_index_indices_deleted_docs_primary)"
+          "meter_elasticsearch_index_indices_docs_primary"
         ],
         "expressionLabels": [
           "all",
-          "primary",
-          "deleted"
+          "primary"
         ],
-        "span": 6,
+        "span": 12,
         "rowSpan": 2
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.de.json
@@ -148,27 +148,33 @@
         ]
       },
       {
-        "title": "Verbindungen / Publisher / Consumer",
+        "title": "Verbindungen",
         "expressions": [
-          null,
-          null,
           null
-        ],
-        "expressionLabels": [
-          "verbindungen",
-          "publisher",
-          "consumers"
         ]
       },
       {
-        "title": "Channels + Queues",
+        "title": "Publisher",
         "expressions": [
-          null,
           null
-        ],
-        "expressionLabels": [
-          "channels",
-          "queues"
+        ]
+      },
+      {
+        "title": "Consumer",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Channels",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Queues",
+        "expressions": [
+          null
         ]
       },
       {
@@ -178,9 +184,14 @@
         ]
       },
       {
+        "title": "Zugewiesen gesamt (MB)",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "Speicher (MB)",
         "expressions": [
-          null,
           null,
           null,
           null
@@ -188,8 +199,7 @@
         "expressionLabels": [
           "genutzt",
           "ungenutzt",
-          "resident",
-          "gesamt"
+          "resident"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.es.json
@@ -92,30 +92,32 @@
         "title": "Mensajes sin reconocer"
       },
       {
-        "title": "Conexiones / publicadores / consumidores",
-        "expressionLabels": [
-          "conexiones",
-          "publicadores",
-          "consumidores"
-        ]
+        "title": "Conexiones"
       },
       {
-        "title": "Canales + colas",
-        "expressionLabels": [
-          "canales",
-          "colas"
-        ]
+        "title": "Publicadores"
+      },
+      {
+        "title": "Consumidores"
+      },
+      {
+        "title": "Canales"
+      },
+      {
+        "title": "Colas"
       },
       {
         "title": "% asignado en uso"
+      },
+      {
+        "title": "Total asignado (MB)"
       },
       {
         "title": "Memoria (MB)",
         "expressionLabels": [
           "en uso",
           "sin uso",
-          "residente",
-          "total"
+          "residente"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.fr.json
@@ -94,30 +94,32 @@
         "title": "Messages non acquittés"
       },
       {
-        "title": "Connexions / Publishers / Consumers",
-        "expressionLabels": [
-          "connexions",
-          "publishers",
-          "consumers"
-        ]
+        "title": "Connexions"
       },
       {
-        "title": "Canaux + files",
-        "expressionLabels": [
-          "canaux",
-          "files"
-        ]
+        "title": "Publishers"
+      },
+      {
+        "title": "Consumers"
+      },
+      {
+        "title": "Canaux"
+      },
+      {
+        "title": "Files"
       },
       {
         "title": "Alloué utilisé %"
+      },
+      {
+        "title": "Total alloué (Mo)"
       },
       {
         "title": "Mémoire (Mo)",
         "expressionLabels": [
           "utilisé",
           "inutilisé",
-          "résidente",
-          "total"
+          "résidente"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.ja.json
@@ -94,30 +94,32 @@
         "title": "未確認メッセージ"
       },
       {
-        "title": "接続 / Publisher / Consumer",
-        "expressionLabels": [
-          "接続",
-          "パブリッシャー",
-          "コンシューマー"
-        ]
+        "title": "接続"
       },
       {
-        "title": "Channel + キュー",
-        "expressionLabels": [
-          "channel",
-          "キュー"
-        ]
+        "title": "パブリッシャー"
+      },
+      {
+        "title": "コンシューマー"
+      },
+      {
+        "title": "Channel"
+      },
+      {
+        "title": "キュー"
       },
       {
         "title": "アロケート使用率 %"
+      },
+      {
+        "title": "アロケート合計 (MB)"
       },
       {
         "title": "メモリ (MB)",
         "expressionLabels": [
           "使用中",
           "未使用",
-          "常駐",
-          "合計"
+          "常駐"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.ko.json
@@ -94,30 +94,32 @@
         "title": "확인되지 않은 메시지"
       },
       {
-        "title": "연결 / 게시자 / 소비자",
-        "expressionLabels": [
-          "연결",
-          "게시자",
-          "소비자"
-        ]
+        "title": "연결"
       },
       {
-        "title": "채널 + 큐",
-        "expressionLabels": [
-          "채널",
-          "큐"
-        ]
+        "title": "게시자"
+      },
+      {
+        "title": "소비자"
+      },
+      {
+        "title": "채널"
+      },
+      {
+        "title": "큐"
       },
       {
         "title": "할당 사용 %"
+      },
+      {
+        "title": "할당 총량 (MB)"
       },
       {
         "title": "메모리 (MB)",
         "expressionLabels": [
           "사용",
           "미사용",
-          "resident",
-          "전체"
+          "resident"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.pt.json
@@ -98,30 +98,32 @@
         "title": "Mensagens não reconhecidas"
       },
       {
-        "title": "Conexões / publishers / consumidores",
-        "expressionLabels": [
-          "conexões",
-          "publishers",
-          "consumidores"
-        ]
+        "title": "Conexões"
       },
       {
-        "title": "Channels + filas",
-        "expressionLabels": [
-          "channels",
-          "filas"
-        ]
+        "title": "Publishers"
+      },
+      {
+        "title": "Consumidores"
+      },
+      {
+        "title": "Channels"
+      },
+      {
+        "title": "Filas"
       },
       {
         "title": "% alocado em uso"
+      },
+      {
+        "title": "Total alocado (MB)"
       },
       {
         "title": "Memória (MB)",
         "expressionLabels": [
           "em uso",
           "sem uso",
-          "residente",
-          "total"
+          "residente"
         ]
       },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.i18n.zh-CN.json
@@ -49,18 +49,16 @@
       { "title": "入站消息" },
       { "title": "出站消息" },
       { "title": "未确认消息" },
-      {
-        "title": "连接 / Publisher / Consumer",
-        "expressionLabels": ["connections", "publishers", "consumers"]
-      },
-      {
-        "title": "Channel + 队列",
-        "expressionLabels": ["channels", "queues"]
-      },
+      { "title": "连接" },
+      { "title": "Publisher" },
+      { "title": "Consumer" },
+      { "title": "Channel" },
+      { "title": "队列" },
       { "title": "已分配使用率 %" },
+      { "title": "已分配总量（MB）" },
       {
         "title": "内存（MB）",
-        "expressionLabels": ["used", "unused", "resident", "total"]
+        "expressionLabels": ["used", "unused", "resident"]
       },
       { "title": "按类型分配（MB）" },
       {

--- a/apps/bff/src/bundled_templates/layers/rabbitmq.json
+++ b/apps/bff/src/bundled_templates/layers/rabbitmq.json
@@ -200,7 +200,7 @@
         "expressions": [
           "latest(meter_rabbitmq_node_queue_messages_ready)"
         ],
-        "span": 4,
+        "span": 3,
         "rowSpan": 1
       },
       {
@@ -210,7 +210,7 @@
         "expressions": [
           "latest(meter_rabbitmq_node_incoming_messages)"
         ],
-        "span": 4,
+        "span": 3,
         "rowSpan": 1
       },
       {
@@ -220,7 +220,7 @@
         "expressions": [
           "latest(meter_rabbitmq_node_outgoing_messages_total)"
         ],
-        "span": 4,
+        "span": 3,
         "rowSpan": 1
       },
       {
@@ -230,40 +230,58 @@
         "expressions": [
           "latest(meter_rabbitmq_node_unacknowledged_messages)"
         ],
-        "span": 4,
+        "span": 3,
         "rowSpan": 1
       },
       {
         "id": "conns",
-        "title": "Connections / Publishers / Consumers",
-        "type": "line",
+        "title": "Connections",
+        "type": "card",
         "expressions": [
-          "latest(meter_rabbitmq_node_connections_total)",
-          "latest(meter_rabbitmq_node_publisher_total)",
+          "latest(meter_rabbitmq_node_connections_total)"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "publishers",
+        "title": "Publishers",
+        "type": "card",
+        "expressions": [
+          "latest(meter_rabbitmq_node_publisher_total)"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "consumers",
+        "title": "Consumers",
+        "type": "card",
+        "expressions": [
           "latest(meter_rabbitmq_node_consumer_total)"
         ],
-        "expressionLabels": [
-          "connections",
-          "publishers",
-          "consumers"
-        ],
-        "span": 4,
-        "rowSpan": 2
+        "span": 3,
+        "rowSpan": 1
       },
       {
         "id": "channels",
-        "title": "Channels + Queues",
-        "type": "line",
+        "title": "Channels",
+        "type": "card",
         "expressions": [
-          "latest(meter_rabbitmq_node_channel_total)",
+          "latest(meter_rabbitmq_node_channel_total)"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "queues",
+        "title": "Queues",
+        "type": "card",
+        "expressions": [
           "latest(meter_rabbitmq_node_queue_total)"
         ],
-        "expressionLabels": [
-          "channels",
-          "queues"
-        ],
         "span": 4,
-        "rowSpan": 2
+        "rowSpan": 1
       },
       {
         "id": "memory_pct",
@@ -277,6 +295,17 @@
         "rowSpan": 1
       },
       {
+        "id": "memory_bytes_total",
+        "title": "Allocated Total (MB)",
+        "type": "card",
+        "unit": "MB",
+        "expressions": [
+          "latest(meter_rabbitmq_node_allocated_total_bytes)/1024/1024"
+        ],
+        "span": 4,
+        "rowSpan": 1
+      },
+      {
         "id": "memory_bytes",
         "title": "Memory (MB)",
         "type": "line",
@@ -284,16 +313,14 @@
         "expressions": [
           "meter_rabbitmq_node_allocated_used_bytes/1024/1024",
           "meter_rabbitmq_node_allocated_unused_bytes/1024/1024",
-          "meter_rabbitmq_node_process_resident_memory_bytes/1024/1024",
-          "latest(meter_rabbitmq_node_allocated_total_bytes)/1024/1024"
+          "meter_rabbitmq_node_process_resident_memory_bytes/1024/1024"
         ],
         "expressionLabels": [
           "used",
           "unused",
-          "resident",
-          "total"
+          "resident"
         ],
-        "span": 8,
+        "span": 6,
         "rowSpan": 2
       },
       {
@@ -324,7 +351,7 @@
           "single used",
           "single unused"
         ],
-        "span": 6,
+        "span": 12,
         "rowSpan": 2
       }
     ]

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.de.json
@@ -72,25 +72,9 @@
         ]
       },
       {
-        "title": "CommitLog Disk-Verhältnis (%)",
+        "title": "Max. CommitLog-Disk-Ratio (%)",
         "expressions": [
-          null,
           null
-        ],
-        "expressionLabels": [
-          "aktuell",
-          "max"
-        ]
-      },
-      {
-        "title": "ThreadPool Queue-Head-Wartezeit (ms)",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "pull",
-          "senden"
         ]
       },
       {
@@ -103,6 +87,23 @@
         "title": "Broker",
         "expressions": [
           null
+        ]
+      },
+      {
+        "title": "CommitLog Disk-Verhältnis (%)",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "ThreadPool Queue-Head-Wartezeit (ms)",
+        "expressions": [
+          null,
+          null
+        ],
+        "expressionLabels": [
+          "pull",
+          "senden"
         ]
       }
     ],
@@ -134,6 +135,30 @@
     ],
     "endpoint": [
       {
+        "title": "Max. Producer-Nachrichtengröße (MB)",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Max. Consumer-Nachrichtengröße (MB)",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Consumer-Group-Anzahl",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Broker-Anzahl",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "Producer / Consumer-Group TPS",
         "expressions": [
           null,
@@ -156,23 +181,6 @@
         ]
       },
       {
-        "title": "Max. Nachrichtengröße (MB)",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "producer",
-          "consumer"
-        ]
-      },
-      {
-        "title": "Consumer-Latenz (s)",
-        "expressions": [
-          null
-        ]
-      },
-      {
         "title": "Producer / Consumer-Offsets",
         "expressions": [
           null,
@@ -191,13 +199,7 @@
         ]
       },
       {
-        "title": "Consumer-Group-Anzahl",
-        "expressions": [
-          null
-        ]
-      },
-      {
-        "title": "Broker-Anzahl",
+        "title": "Consumer-Latenz (s)",
         "expressions": [
           null
         ]

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.es.json
@@ -47,11 +47,16 @@
         "title": "Latencia máxima del consumidor"
       },
       {
-        "title": "Ratio de disco de CommitLog (%)",
-        "expressionLabels": [
-          "actual",
-          "máx"
-        ]
+        "title": "Ratio máximo de disco de CommitLog (%)"
+      },
+      {
+        "title": "Topics"
+      },
+      {
+        "title": "Brokers"
+      },
+      {
+        "title": "Ratio de disco de CommitLog (%)"
       },
       {
         "title": "Espera en cabeza de cola del ThreadPool (ms)",
@@ -59,12 +64,6 @@
           "pull",
           "envío"
         ]
-      },
-      {
-        "title": "Topics"
-      },
-      {
-        "title": "Brokers"
       }
     ],
     "instance": [
@@ -83,6 +82,18 @@
     ],
     "endpoint": [
       {
+        "title": "Tamaño máx. de mensaje del productor (MB)"
+      },
+      {
+        "title": "Tamaño máx. de mensaje del consumidor (MB)"
+      },
+      {
+        "title": "Conteo de grupos de consumo"
+      },
+      {
+        "title": "Conteo de brokers"
+      },
+      {
         "title": "TPS de grupos productor / consumidor",
         "expressionLabels": [
           "productor",
@@ -97,16 +108,6 @@
         ]
       },
       {
-        "title": "Tamaño máximo de mensaje (MB)",
-        "expressionLabels": [
-          "productor",
-          "consumidor"
-        ]
-      },
-      {
-        "title": "Latencia del consumidor (s)"
-      },
-      {
         "title": "Offsets productor / consumidor",
         "expressionLabels": [
           "productor",
@@ -118,10 +119,7 @@
         "tip": "Offset del productor menos offset del grupo de consumo — el lag del topic."
       },
       {
-        "title": "Conteo de grupos de consumo"
-      },
-      {
-        "title": "Conteo de brokers"
+        "title": "Latencia del consumidor (s)"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.fr.json
@@ -49,11 +49,16 @@
         "title": "Latence consumer max"
       },
       {
-        "title": "Ratio disque du CommitLog (%)",
-        "expressionLabels": [
-          "courant",
-          "max"
-        ]
+        "title": "Ratio disque CommitLog max (%)"
+      },
+      {
+        "title": "Topics"
+      },
+      {
+        "title": "Brokers"
+      },
+      {
+        "title": "Ratio disque du CommitLog (%)"
       },
       {
         "title": "Attente en tête de file du ThreadPool (ms)",
@@ -61,12 +66,6 @@
           "pull",
           "envoi"
         ]
-      },
-      {
-        "title": "Topics"
-      },
-      {
-        "title": "Brokers"
       }
     ],
     "instance": [
@@ -85,6 +84,18 @@
     ],
     "endpoint": [
       {
+        "title": "Taille max. de message producteur (Mo)"
+      },
+      {
+        "title": "Taille max. de message consommateur (Mo)"
+      },
+      {
+        "title": "Nombre de groupes de consumers"
+      },
+      {
+        "title": "Nombre de brokers"
+      },
+      {
         "title": "TPS par groupe producteur / consommateur",
         "expressionLabels": [
           "producteur",
@@ -99,16 +110,6 @@
         ]
       },
       {
-        "title": "Taille de message max (Mo)",
-        "expressionLabels": [
-          "producteur",
-          "consommateur"
-        ]
-      },
-      {
-        "title": "Latence des consumers (s)"
-      },
-      {
         "title": "Offsets producer / consumer",
         "expressionLabels": [
           "producteur",
@@ -120,10 +121,7 @@
         "tip": "Offset producer moins offset du groupe consumer — le lag du topic."
       },
       {
-        "title": "Nombre de groupes de consumers"
-      },
-      {
-        "title": "Nombre de brokers"
+        "title": "Latence des consumers (s)"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.ja.json
@@ -49,11 +49,16 @@
         "title": "最大コンシューマーレイテンシ"
       },
       {
-        "title": "CommitLog ディスク比率 (%)",
-        "expressionLabels": [
-          "現在",
-          "最大"
-        ]
+        "title": "最大 CommitLog ディスク比率 (%)"
+      },
+      {
+        "title": "Topic"
+      },
+      {
+        "title": "Broker"
+      },
+      {
+        "title": "CommitLog ディスク比率 (%)"
       },
       {
         "title": "ThreadPool キュー先頭待ち (ms)",
@@ -61,12 +66,6 @@
           "プル",
           "送信"
         ]
-      },
-      {
-        "title": "Topic"
-      },
-      {
-        "title": "Broker"
       }
     ],
     "instance": [
@@ -85,6 +84,18 @@
     ],
     "endpoint": [
       {
+        "title": "最大プロデューサーメッセージサイズ (MB)"
+      },
+      {
+        "title": "最大コンシューマーメッセージサイズ (MB)"
+      },
+      {
+        "title": "コンシューマーグループ数"
+      },
+      {
+        "title": "Broker 数"
+      },
+      {
         "title": "プロデューサー / コンシューマーグループ TPS",
         "expressionLabels": [
           "プロデューサー",
@@ -99,16 +110,6 @@
         ]
       },
       {
-        "title": "最大メッセージサイズ (MB)",
-        "expressionLabels": [
-          "プロデューサー",
-          "コンシューマー"
-        ]
-      },
-      {
-        "title": "コンシューマーレイテンシ (s)"
-      },
-      {
         "title": "プロデューサー / コンシューマーオフセット",
         "expressionLabels": [
           "プロデューサー",
@@ -120,10 +121,7 @@
         "tip": "プロデューサーオフセット − コンシューマーグループオフセット — Topic のラグ。"
       },
       {
-        "title": "コンシューマーグループ数"
-      },
-      {
-        "title": "Broker 数"
+        "title": "コンシューマーレイテンシ (s)"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.ko.json
@@ -49,11 +49,16 @@
         "title": "최대 소비자 지연 시간"
       },
       {
-        "title": "CommitLog 디스크 비율 (%)",
-        "expressionLabels": [
-          "current",
-          "최대"
-        ]
+        "title": "최대 CommitLog 디스크 비율 (%)"
+      },
+      {
+        "title": "Topic"
+      },
+      {
+        "title": "Broker"
+      },
+      {
+        "title": "CommitLog 디스크 비율 (%)"
       },
       {
         "title": "스레드풀 큐 헤드 대기 (ms)",
@@ -61,12 +66,6 @@
           "pull",
           "전송"
         ]
-      },
-      {
-        "title": "Topic"
-      },
-      {
-        "title": "Broker"
       }
     ],
     "instance": [
@@ -85,6 +84,18 @@
     ],
     "endpoint": [
       {
+        "title": "최대 프로듀서 메시지 크기 (MB)"
+      },
+      {
+        "title": "최대 컨슈머 메시지 크기 (MB)"
+      },
+      {
+        "title": "소비자 그룹 수"
+      },
+      {
+        "title": "브로커 수"
+      },
+      {
         "title": "생산자 / 소비자 그룹 TPS",
         "expressionLabels": [
           "생산자",
@@ -99,16 +110,6 @@
         ]
       },
       {
-        "title": "최대 메시지 크기 (MB)",
-        "expressionLabels": [
-          "생산자",
-          "소비자"
-        ]
-      },
-      {
-        "title": "소비자 지연 시간 (s)"
-      },
-      {
         "title": "생산자 / 소비자 오프셋",
         "expressionLabels": [
           "생산자",
@@ -120,10 +121,7 @@
         "tip": "생산자 오프셋에서 소비자 그룹 오프셋을 뺀 값 — 토픽 랙입니다."
       },
       {
-        "title": "소비자 그룹 수"
-      },
-      {
-        "title": "브로커 수"
+        "title": "소비자 지연 시간 (s)"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.pt.json
@@ -54,11 +54,16 @@
         "title": "Latência máxima do consumidor"
       },
       {
-        "title": "Ratio de disco do CommitLog (%)",
-        "expressionLabels": [
-          "atual",
-          "máx"
-        ]
+        "title": "Razão máxima de disco do CommitLog (%)"
+      },
+      {
+        "title": "Topics"
+      },
+      {
+        "title": "Brokers"
+      },
+      {
+        "title": "Ratio de disco do CommitLog (%)"
       },
       {
         "title": "Espera na cabeça da fila do ThreadPool (ms)",
@@ -66,12 +71,6 @@
           "pull",
           "send"
         ]
-      },
-      {
-        "title": "Topics"
-      },
-      {
-        "title": "Brokers"
       }
     ],
     "instance": [
@@ -90,6 +89,18 @@
     ],
     "endpoint": [
       {
+        "title": "Tamanho máx. de mensagem do produtor (MB)"
+      },
+      {
+        "title": "Tamanho máx. de mensagem do consumidor (MB)"
+      },
+      {
+        "title": "Quantidade de consumer groups"
+      },
+      {
+        "title": "Quantidade de brokers"
+      },
+      {
         "title": "TPS de grupos produtor / consumidor",
         "expressionLabels": [
           "produtor",
@@ -104,16 +115,6 @@
         ]
       },
       {
-        "title": "Tamanho máximo da mensagem (MB)",
-        "expressionLabels": [
-          "produtor",
-          "consumidor"
-        ]
-      },
-      {
-        "title": "Latência do consumidor (s)"
-      },
-      {
         "title": "Offsets produtor / consumidor",
         "expressionLabels": [
           "produtor",
@@ -125,10 +126,7 @@
         "tip": "Offset do produtor menos offset do consumer group — o lag do topic."
       },
       {
-        "title": "Quantidade de consumer groups"
-      },
-      {
-        "title": "Quantidade de brokers"
+        "title": "Latência do consumidor (s)"
       }
     ]
   }

--- a/apps/bff/src/bundled_templates/layers/rocketmq.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.i18n.zh-CN.json
@@ -29,16 +29,14 @@
         "expressionLabels": ["produced", "consumed"]
       },
       { "title": "最大消费延迟" },
-      {
-        "title": "CommitLog 磁盘占比（%）",
-        "expressionLabels": ["current", "max"]
-      },
+      { "title": "最大 CommitLog 磁盘占比（%）" },
+      { "title": "Topic" },
+      { "title": "Broker" },
+      { "title": "CommitLog 磁盘占比（%）" },
       {
         "title": "线程池队列头等待（ms）",
         "expressionLabels": ["pull", "send"]
-      },
-      { "title": "Topic" },
-      { "title": "Broker" }
+      }
     ],
     "instance": [
       { "title": "生产 TPS" },
@@ -47,6 +45,10 @@
       { "title": "Consumer 消息大小（MB）" }
     ],
     "endpoint": [
+      { "title": "最大生产者消息大小（MB）" },
+      { "title": "最大消费者消息大小（MB）" },
+      { "title": "Consumer Group 数量" },
+      { "title": "Broker 数量" },
       {
         "title": "Producer / Consumer Group TPS",
         "expressionLabels": ["producer", "consumer group"]
@@ -56,11 +58,6 @@
         "expressionLabels": ["produced", "consumed"]
       },
       {
-        "title": "最大消息大小（MB）",
-        "expressionLabels": ["producer", "consumer"]
-      },
-      { "title": "消费延迟（s）" },
-      {
         "title": "Producer / Consumer Offset",
         "expressionLabels": ["producer", "consumer group"]
       },
@@ -68,8 +65,7 @@
         "title": "积压消息",
         "tip": "Producer offset 减去 Consumer-group offset — 即 Topic 的 Lag。"
       },
-      { "title": "Consumer Group 数量" },
-      { "title": "Broker 数量" }
+      { "title": "消费延迟（s）" }
     ]
   }
 }

--- a/apps/bff/src/bundled_templates/layers/rocketmq.json
+++ b/apps/bff/src/bundled_templates/layers/rocketmq.json
@@ -130,40 +130,19 @@
         "expressions": [
           "latest(meter_rocketmq_cluster_max_consumer_latency)"
         ],
-        "span": 4,
+        "span": 3,
         "rowSpan": 1
       },
       {
-        "id": "commitlog_ratio",
-        "title": "CommitLog Disk Ratio (%)",
-        "type": "line",
+        "id": "commitlog_ratio_total",
+        "title": "Max CommitLog Disk Ratio (%)",
+        "type": "card",
         "unit": "%",
         "expressions": [
-          "meter_rocketmq_cluster_commitLog_disk_ratio",
           "latest(meter_rocketmq_cluster_max_commitLog_disk_ratio)"
         ],
-        "expressionLabels": [
-          "current",
-          "max"
-        ],
-        "span": 4,
-        "rowSpan": 2
-      },
-      {
-        "id": "queue_wait",
-        "title": "ThreadPool Queue Head Wait (ms)",
-        "type": "line",
-        "unit": "ms",
-        "expressions": [
-          "meter_rocketmq_cluster_pull_threadPool_queue_head_wait_time",
-          "meter_rocketmq_cluster_send_threadPool_queue_head_wait_time"
-        ],
-        "expressionLabels": [
-          "pull",
-          "send"
-        ],
-        "span": 4,
-        "rowSpan": 2
+        "span": 3,
+        "rowSpan": 1
       },
       {
         "id": "topic_count",
@@ -186,6 +165,33 @@
         "span": 3,
         "rowSpan": 1,
         "format": "int"
+      },
+      {
+        "id": "commitlog_ratio",
+        "title": "CommitLog Disk Ratio (%)",
+        "type": "line",
+        "unit": "%",
+        "expressions": [
+          "meter_rocketmq_cluster_commitLog_disk_ratio"
+        ],
+        "span": 6,
+        "rowSpan": 2
+      },
+      {
+        "id": "queue_wait",
+        "title": "ThreadPool Queue Head Wait (ms)",
+        "type": "line",
+        "unit": "ms",
+        "expressions": [
+          "meter_rocketmq_cluster_pull_threadPool_queue_head_wait_time",
+          "meter_rocketmq_cluster_send_threadPool_queue_head_wait_time"
+        ],
+        "expressionLabels": [
+          "pull",
+          "send"
+        ],
+        "span": 6,
+        "rowSpan": 2
       }
     ],
     "instance": [
@@ -234,6 +240,48 @@
     ],
     "endpoint": [
       {
+        "id": "max_msg_producer_total",
+        "title": "Max Producer Msg Size (MB)",
+        "type": "card",
+        "unit": "MB",
+        "expressions": [
+          "latest(meter_rocketmq_topic_max_producer_message_size)/1024/1024"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "max_msg_consumer_total",
+        "title": "Max Consumer Msg Size (MB)",
+        "type": "card",
+        "unit": "MB",
+        "expressions": [
+          "latest(meter_rocketmq_topic_max_consumer_message_size)/1024/1024"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "consumer_groups",
+        "title": "Consumer Group Count",
+        "type": "card",
+        "expressions": [
+          "latest(meter_rocketmq_topic_consumer_group_count)"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
+        "id": "brokers",
+        "title": "Broker Count",
+        "type": "card",
+        "expressions": [
+          "latest(meter_rocketmq_topic_broker_count)"
+        ],
+        "span": 3,
+        "rowSpan": 1
+      },
+      {
         "id": "tps",
         "title": "Producer / Consumer Group TPS",
         "type": "line",
@@ -265,33 +313,6 @@
         "rowSpan": 2
       },
       {
-        "id": "max_msg",
-        "title": "Max Message Size (MB)",
-        "type": "line",
-        "unit": "MB",
-        "expressions": [
-          "latest(meter_rocketmq_topic_max_producer_message_size)/1024/1024",
-          "latest(meter_rocketmq_topic_max_consumer_message_size)/1024/1024"
-        ],
-        "expressionLabels": [
-          "producer",
-          "consumer"
-        ],
-        "span": 6,
-        "rowSpan": 2
-      },
-      {
-        "id": "consumer_latency",
-        "title": "Consumer Latency (s)",
-        "type": "line",
-        "unit": "s",
-        "expressions": [
-          "meter_rocketmq_topic_consumer_latency/1000"
-        ],
-        "span": 6,
-        "rowSpan": 2
-      },
-      {
         "id": "offsets",
         "title": "Producer / Consumer Offsets",
         "type": "line",
@@ -318,24 +339,15 @@
         "rowSpan": 2
       },
       {
-        "id": "consumer_groups",
-        "title": "Consumer Group Count",
-        "type": "card",
+        "id": "consumer_latency",
+        "title": "Consumer Latency (s)",
+        "type": "line",
+        "unit": "s",
         "expressions": [
-          "latest(meter_rocketmq_topic_consumer_group_count)"
+          "meter_rocketmq_topic_consumer_latency/1000"
         ],
-        "span": 6,
-        "rowSpan": 1
-      },
-      {
-        "id": "brokers",
-        "title": "Broker Count",
-        "type": "card",
-        "expressions": [
-          "latest(meter_rocketmq_topic_broker_count)"
-        ],
-        "span": 6,
-        "rowSpan": 1
+        "span": 12,
+        "rowSpan": 2
       }
     ]
   }

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.de.json
@@ -20,131 +20,73 @@
   "dashboards": {
     "service": [
       {
-        "title": "Aufrufe / min",
-        "expressions": [
-          null
-        ]
+        "title": "Aufrufe / min"
       },
       {
-        "title": "Mittlere Antwortzeit",
-        "expressions": [
-          null
-        ]
+        "title": "Mittlere Antwortzeit"
       },
       {
-        "title": "Erfolgsrate",
-        "expressions": [
-          null
-        ]
+        "title": "Erfolgsrate"
       },
       {
-        "title": "Latenz-Perzentil",
-        "expressions": [
-          null
-        ]
+        "title": "Latenz-Perzentil"
       },
       {
-        "title": "Input-Tokens",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "summe",
-          "mittel"
-        ]
+        "title": "Input-Tokens"
       },
       {
-        "title": "Output-Tokens",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "summe",
-          "mittel"
-        ]
+        "title": "Output-Tokens"
       },
       {
-        "title": "Geschätzte Kosten",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "gesamt",
-          "mittel"
-        ]
+        "title": "Geschätzte Gesamtkosten"
+      },
+      {
+        "title": "Mittlere Input-Tokens"
+      },
+      {
+        "title": "Mittlere Output-Tokens"
+      },
+      {
+        "title": "Mittlere geschätzte Kosten"
       }
     ],
     "instance": [
       {
-        "title": "Aufrufe / min",
-        "expressions": [
-          null
-        ]
+        "title": "Aufrufe / min"
       },
       {
-        "title": "Mittlere Latenz",
-        "expressions": [
-          null
-        ]
+        "title": "Mittlere Latenz"
       },
       {
-        "title": "Erfolgsrate",
-        "expressions": [
-          null
-        ]
+        "title": "Erfolgsrate"
       },
       {
-        "title": "Latenz-Perzentil",
-        "expressions": [
-          null
-        ]
+        "title": "Latenz-Perzentil"
       },
       {
         "title": "TTFT",
-        "expressions": [
-          null,
-          null
-        ],
         "expressionLabels": [
           "mittel",
           "perzentil"
         ]
       },
       {
-        "title": "Input-Tokens",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "summe",
-          "mittel"
-        ]
+        "title": "Input-Tokens"
       },
       {
-        "title": "Output-Tokens",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "summe",
-          "mittel"
-        ]
+        "title": "Output-Tokens"
       },
       {
-        "title": "Geschätzte Kosten",
-        "expressions": [
-          null,
-          null
-        ],
-        "expressionLabels": [
-          "gesamt",
-          "mittel"
-        ]
+        "title": "Geschätzte Gesamtkosten"
+      },
+      {
+        "title": "Mittlere Input-Tokens"
+      },
+      {
+        "title": "Mittlere Output-Tokens"
+      },
+      {
+        "title": "Mittlere geschätzte Kosten"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.es.json
@@ -31,25 +31,22 @@
         "title": "Percentil de latencia"
       },
       {
-        "title": "Tokens de entrada",
-        "expressionLabels": [
-          "suma",
-          "media"
-        ]
+        "title": "Tokens de entrada"
       },
       {
-        "title": "Tokens de salida",
-        "expressionLabels": [
-          "suma",
-          "media"
-        ]
+        "title": "Tokens de salida"
       },
       {
-        "title": "Coste estimado",
-        "expressionLabels": [
-          "total",
-          "media"
-        ]
+        "title": "Coste estimado total"
+      },
+      {
+        "title": "Tokens de entrada promedio"
+      },
+      {
+        "title": "Tokens de salida promedio"
+      },
+      {
+        "title": "Coste estimado promedio"
       }
     ],
     "instance": [
@@ -73,25 +70,22 @@
         ]
       },
       {
-        "title": "Tokens de entrada",
-        "expressionLabels": [
-          "suma",
-          "media"
-        ]
+        "title": "Tokens de entrada"
       },
       {
-        "title": "Tokens de salida",
-        "expressionLabels": [
-          "suma",
-          "media"
-        ]
+        "title": "Tokens de salida"
       },
       {
-        "title": "Coste estimado",
-        "expressionLabels": [
-          "total",
-          "media"
-        ]
+        "title": "Coste estimado total"
+      },
+      {
+        "title": "Tokens de entrada promedio"
+      },
+      {
+        "title": "Tokens de salida promedio"
+      },
+      {
+        "title": "Coste estimado promedio"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.fr.json
@@ -32,25 +32,22 @@
         "title": "Centile de latence"
       },
       {
-        "title": "Tokens entrants",
-        "expressionLabels": [
-          "somme",
-          "moy"
-        ]
+        "title": "Tokens entrants"
       },
       {
-        "title": "Tokens sortants",
-        "expressionLabels": [
-          "somme",
-          "moy"
-        ]
+        "title": "Tokens sortants"
       },
       {
-        "title": "Coût estimé",
-        "expressionLabels": [
-          "total",
-          "moy"
-        ]
+        "title": "Coût total estimé"
+      },
+      {
+        "title": "Tokens entrants moyens"
+      },
+      {
+        "title": "Tokens sortants moyens"
+      },
+      {
+        "title": "Coût estimé moyen"
       }
     ],
     "instance": [
@@ -74,25 +71,22 @@
         ]
       },
       {
-        "title": "Tokens entrants",
-        "expressionLabels": [
-          "somme",
-          "moy"
-        ]
+        "title": "Tokens entrants"
       },
       {
-        "title": "Tokens sortants",
-        "expressionLabels": [
-          "somme",
-          "moy"
-        ]
+        "title": "Tokens sortants"
       },
       {
-        "title": "Coût estimé",
-        "expressionLabels": [
-          "total",
-          "moy"
-        ]
+        "title": "Coût total estimé"
+      },
+      {
+        "title": "Tokens entrants moyens"
+      },
+      {
+        "title": "Tokens sortants moyens"
+      },
+      {
+        "title": "Coût estimé moyen"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.ja.json
@@ -32,25 +32,22 @@
         "title": "レイテンシパーセンタイル"
       },
       {
-        "title": "入力トークン",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "入力トークン"
       },
       {
-        "title": "出力トークン",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "出力トークン"
       },
       {
-        "title": "推定コスト",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "総推定コスト"
+      },
+      {
+        "title": "平均入力トークン"
+      },
+      {
+        "title": "平均出力トークン"
+      },
+      {
+        "title": "平均推定コスト"
       }
     ],
     "instance": [
@@ -74,25 +71,22 @@
         ]
       },
       {
-        "title": "入力トークン",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "入力トークン"
       },
       {
-        "title": "出力トークン",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "出力トークン"
       },
       {
-        "title": "推定コスト",
-        "expressionLabels": [
-          "合計",
-          "平均"
-        ]
+        "title": "総推定コスト"
+      },
+      {
+        "title": "平均入力トークン"
+      },
+      {
+        "title": "平均出力トークン"
+      },
+      {
+        "title": "平均推定コスト"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.ko.json
@@ -32,25 +32,22 @@
         "title": "지연 시간 백분위"
       },
       {
-        "title": "입력 토큰",
-        "expressionLabels": [
-          "합계",
-          "평균"
-        ]
+        "title": "입력 토큰"
       },
       {
-        "title": "출력 토큰",
-        "expressionLabels": [
-          "합계",
-          "평균"
-        ]
+        "title": "출력 토큰"
       },
       {
-        "title": "추정 비용",
-        "expressionLabels": [
-          "전체",
-          "평균"
-        ]
+        "title": "총 추정 비용"
+      },
+      {
+        "title": "평균 입력 토큰"
+      },
+      {
+        "title": "평균 출력 토큰"
+      },
+      {
+        "title": "평균 추정 비용"
       }
     ],
     "instance": [
@@ -74,25 +71,22 @@
         ]
       },
       {
-        "title": "입력 토큰",
-        "expressionLabels": [
-          "합계",
-          "평균"
-        ]
+        "title": "입력 토큰"
       },
       {
-        "title": "출력 토큰",
-        "expressionLabels": [
-          "합계",
-          "평균"
-        ]
+        "title": "출력 토큰"
       },
       {
-        "title": "추정 비용",
-        "expressionLabels": [
-          "전체",
-          "평균"
-        ]
+        "title": "총 추정 비용"
+      },
+      {
+        "title": "평균 입력 토큰"
+      },
+      {
+        "title": "평균 출력 토큰"
+      },
+      {
+        "title": "평균 추정 비용"
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.pt.json
@@ -36,25 +36,22 @@
         "title": "Percentil de latência"
       },
       {
-        "title": "Tokens de entrada",
-        "expressionLabels": [
-          "soma",
-          "média"
-        ]
+        "title": "Tokens de entrada"
       },
       {
-        "title": "Tokens de saída",
-        "expressionLabels": [
-          "soma",
-          "média"
-        ]
+        "title": "Tokens de saída"
       },
       {
-        "title": "Custo estimado",
-        "expressionLabels": [
-          "total",
-          "média"
-        ]
+        "title": "Custo estimado total"
+      },
+      {
+        "title": "Tokens de entrada médios"
+      },
+      {
+        "title": "Tokens de saída médios"
+      },
+      {
+        "title": "Custo estimado médio"
       }
     ],
     "instance": [
@@ -78,25 +75,22 @@
         ]
       },
       {
-        "title": "Tokens de entrada",
-        "expressionLabels": [
-          "soma",
-          "média"
-        ]
+        "title": "Tokens de entrada"
       },
       {
-        "title": "Tokens de saída",
-        "expressionLabels": [
-          "soma",
-          "média"
-        ]
+        "title": "Tokens de saída"
       },
       {
-        "title": "Custo estimado",
-        "expressionLabels": [
-          "total",
-          "média"
-        ]
+        "title": "Custo estimado total"
+      },
+      {
+        "title": "Tokens de entrada médios"
+      },
+      {
+        "title": "Tokens de saída médios"
+      },
+      {
+        "title": "Custo estimado médio"
       }
     ]
   }

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.i18n.zh-CN.json
@@ -19,18 +19,12 @@
       { "title": "平均响应时间" },
       { "title": "成功率" },
       { "title": "延迟分位" },
-      {
-        "title": "输入 Token",
-        "expressionLabels": ["sum", "avg"]
-      },
-      {
-        "title": "输出 Token",
-        "expressionLabels": ["sum", "avg"]
-      },
-      {
-        "title": "预估成本",
-        "expressionLabels": ["total", "avg"]
-      }
+      { "title": "输入 Token" },
+      { "title": "输出 Token" },
+      { "title": "总预估成本" },
+      { "title": "平均输入 Token" },
+      { "title": "平均输出 Token" },
+      { "title": "平均预估成本" }
     ],
     "instance": [
       { "title": "调用 / 分钟" },
@@ -41,18 +35,12 @@
         "title": "TTFT",
         "expressionLabels": ["avg", "percentile"]
       },
-      {
-        "title": "输入 Token",
-        "expressionLabels": ["sum", "avg"]
-      },
-      {
-        "title": "输出 Token",
-        "expressionLabels": ["sum", "avg"]
-      },
-      {
-        "title": "预估成本",
-        "expressionLabels": ["total", "avg"]
-      }
+      { "title": "输入 Token" },
+      { "title": "输出 Token" },
+      { "title": "总预估成本" },
+      { "title": "平均输入 Token" },
+      { "title": "平均输出 Token" },
+      { "title": "平均预估成本" }
     ]
   }
 }

--- a/apps/bff/src/bundled_templates/layers/virtual_genai.json
+++ b/apps/bff/src/bundled_templates/layers/virtual_genai.json
@@ -95,48 +95,63 @@
         "rowSpan": 2
       },
       {
-        "id": "input_tokens",
+        "id": "input_tokens_total",
         "title": "Input Tokens",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_provider_input_tokens_sum)"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "output_tokens_total",
+        "title": "Output Tokens",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_provider_output_tokens_sum)"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "cost_total",
+        "title": "Total Estimated Cost",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_provider_total_estimated_cost)/1000000"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "input_tokens",
+        "title": "Average Input Tokens",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_provider_input_tokens_sum)",
           "gen_ai_provider_input_tokens_avg"
         ],
-        "expressionLabels": [
-          "sum",
-          "avg"
-        ],
-        "span": 6,
+        "span": 4,
         "rowSpan": 2
       },
       {
         "id": "output_tokens",
-        "title": "Output Tokens",
+        "title": "Average Output Tokens",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_provider_output_tokens_sum)",
           "gen_ai_provider_output_tokens_avg"
         ],
-        "expressionLabels": [
-          "sum",
-          "avg"
-        ],
-        "span": 6,
+        "span": 4,
         "rowSpan": 2
       },
       {
         "id": "cost",
-        "title": "Estimated Cost",
+        "title": "Average Estimated Cost",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_provider_total_estimated_cost)/1000000",
           "gen_ai_provider_avg_estimated_cost/1000000"
         ],
-        "expressionLabels": [
-          "total",
-          "avg"
-        ],
-        "span": 12,
+        "span": 4,
         "rowSpan": 2
       }
     ],
@@ -202,48 +217,63 @@
         "rowSpan": 2
       },
       {
-        "id": "input_tokens",
+        "id": "input_tokens_total",
         "title": "Input Tokens",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_model_input_tokens_sum)"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "output_tokens_total",
+        "title": "Output Tokens",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_model_output_tokens_sum)"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "cost_total",
+        "title": "Total Estimated Cost",
+        "type": "card",
+        "expressions": [
+          "latest(gen_ai_model_total_estimated_cost)/1000000"
+        ],
+        "span": 4,
+        "rowSpan": 2
+      },
+      {
+        "id": "input_tokens",
+        "title": "Average Input Tokens",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_model_input_tokens_sum)",
           "gen_ai_model_input_tokens_avg"
         ],
-        "expressionLabels": [
-          "sum",
-          "avg"
-        ],
-        "span": 6,
+        "span": 4,
         "rowSpan": 2
       },
       {
         "id": "output_tokens",
-        "title": "Output Tokens",
+        "title": "Average Output Tokens",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_model_output_tokens_sum)",
           "gen_ai_model_output_tokens_avg"
         ],
-        "expressionLabels": [
-          "sum",
-          "avg"
-        ],
-        "span": 6,
+        "span": 4,
         "rowSpan": 2
       },
       {
         "id": "cost",
-        "title": "Estimated Cost",
+        "title": "Average Estimated Cost",
         "type": "line",
         "expressions": [
-          "latest(gen_ai_model_total_estimated_cost)/1000000",
           "gen_ai_model_avg_estimated_cost/1000000"
         ],
-        "expressionLabels": [
-          "total",
-          "avg"
-        ],
-        "span": 12,
+        "span": 4,
         "rowSpan": 2
       }
     ]


### PR DESCRIPTION
## Why

Auditing the bundled layer dashboards against the booster-ui originals (the templates Horizon was ported from) surfaced a class of mis-port: widgets whose MQE collapses the window to a single number (a `latest(...)` total) were rendered as `type:"line"`. On screen that's a lone dot that reads as a (broken) time series — and where the total was merged with an average into one widget, two different scales shared one axis. The Virtual GenAI Input/Output Token + Estimated Cost tiles were the most visible case (reported on screen).

## What

Audited **all 46 bundled templates one-by-one** against their booster originals (explicit per-widget comparison, not a grep). **6** carried the mis-port; the other 40 were clean. Each affected widget is split into a single-value **card** (the total) + a trend **line** (the average), matching booster's original Card/Line split and the project's "widget type follows MQE shape" rule.

Affected dashboards:
- **Virtual GenAI** — Input/Output Tokens, Estimated Cost (provider + model scopes)
- **Elasticsearch** — deleted documents
- **ClickHouse** — Zookeeper sessions / watches
- **RabbitMQ** — connection/publisher/consumer/channel/queue totals, allocated memory
- **RocketMQ** — max CommitLog disk ratio, max producer/consumer message size
- **APISIX** — etcd reachability

**Layout:** every changed dashboard row still tiles to exactly full width (12 columns) — no gaps or misaligned rows introduced; a few pre-existing partial rows were closed in passing.

**i18n:** the index-keyed template overlays were realigned across all 7 locales (zh-CN, es, pt, ja, ko, de, fr) for the 6 templates; new card/line titles translated (IT terms kept verbatim).

## Validation

- `i18n:validate` — no findings (was 204).
- All changed templates + overlays valid JSON; BFF builds; 124 unit tests pass.
- Per-widget diff against booster confirmed faithful (card↔Card, line↔Line); per-section row-fill verified (Σ span×rowSpan).
- Not yet rendered against a live OAP carrying these layers' data (the public demo lacks GenAI/etc. data) — the change is structural (widget type + layout), validated against booster-ui as the reference spec.