### PR TITLE
Add PHP PHM instance dashboard widgets and i18n overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to Apache SkyWalking Horizon UI, written from the operator's poi
 
 The version line is shared by every package in the monorepo (apps + shared packages) plus the BFF's `HORIZON_VERSION` default.
 
+## 1.1.0
+
+### General Service — PHP runtime (PHM)
+
+- **Six instance dashboard line widgets for PHP Health Metrics** — process CPU utilization, memory used/peak, virtual memory, thread count, and open file descriptors (`meter_instance_php_*`). Each line widget uses `visibleWhen` so widgets render only when the PHP agent reports PHM data (Linux `/proc` sampling of the parent PHP process via `getppid()`).
+
 ## 1.0.0
 
 ### Performance & behavior tuning

--- a/apps/bff/src/bundled_templates/layers/general.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.de.json
@@ -621,6 +621,48 @@
           "live",
           "verfügbar"
         ]
+      },
+      {
+        "title": "PHP-CPU-Auslastung",
+        "tip": "PHP-Agent: CPU-Auslastung (%) des übergeordneten PHP-Prozesses (getppid()), via /proc gesampelt.",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "PHP-Speicher belegt",
+        "tip": "PHP-Agent: Resident Memory (MB) des übergeordneten PHP-Prozesses (getppid()) (/proc VmRSS).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "PHP-Speicher-Peak",
+        "tip": "PHP-Agent: Peak Resident Memory (MB) des übergeordneten PHP-Prozesses (getppid()) (/proc VmHWM).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "PHP-Virtueller Speicher",
+        "tip": "PHP-Agent: Virtueller Speicher (MB) des übergeordneten PHP-Prozesses (getppid()) (/proc VmSize).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "PHP-Thread-Anzahl",
+        "tip": "PHP-Agent: OS-Thread-Anzahl des übergeordneten PHP-Prozesses (getppid()) (/proc Threads).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "PHP-Offene FDs",
+        "tip": "PHP-Agent: Anzahl offener File Descriptors des übergeordneten PHP-Prozesses (getppid()) (/proc/pid/fd).",
+        "expressions": [
+          null
+        ]
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.es.json
@@ -375,6 +375,30 @@
           "vivas",
           "disponible"
         ]
+      },
+      {
+        "title": "Utilización de CPU de PHP",
+        "tip": "Agente PHP: utilización de CPU (%) del proceso PHP padre (getppid()), muestreada desde /proc."
+      },
+      {
+        "title": "Memoria usada de PHP",
+        "tip": "Agente PHP: memoria residente (MB) del proceso PHP padre (getppid()) (/proc VmRSS)."
+      },
+      {
+        "title": "Pico de memoria de PHP",
+        "tip": "Agente PHP: pico de memoria residente (MB) del proceso PHP padre (getppid()) (/proc VmHWM)."
+      },
+      {
+        "title": "Memoria virtual de PHP",
+        "tip": "Agente PHP: memoria virtual (MB) del proceso PHP padre (getppid()) (/proc VmSize)."
+      },
+      {
+        "title": "Conteo de hilos de PHP",
+        "tip": "Agente PHP: conteo de hilos OS del proceso PHP padre (getppid()) (/proc Threads)."
+      },
+      {
+        "title": "FD abiertos de PHP",
+        "tip": "Agente PHP: conteo de file descriptors abiertos del proceso PHP padre (getppid()) (/proc/pid/fd)."
       }
     ]
   },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.fr.json
@@ -358,6 +358,30 @@
           "vivantes",
           "disponible"
         ]
+      },
+      {
+        "title": "Utilisation CPU PHP",
+        "tip": "Agent PHP : utilisation CPU (%) du processus PHP parent (getppid()), échantillonnée via /proc."
+      },
+      {
+        "title": "Mémoire PHP utilisée",
+        "tip": "Agent PHP : mémoire résidente (MB) du processus PHP parent (getppid()) (/proc VmRSS)."
+      },
+      {
+        "title": "Pic mémoire PHP",
+        "tip": "Agent PHP : pic de mémoire résidente (MB) du processus PHP parent (getppid()) (/proc VmHWM)."
+      },
+      {
+        "title": "Mémoire virtuelle PHP",
+        "tip": "Agent PHP : mémoire virtuelle (MB) du processus PHP parent (getppid()) (/proc VmSize)."
+      },
+      {
+        "title": "Nombre de threads PHP",
+        "tip": "Agent PHP : nombre de threads OS du processus PHP parent (getppid()) (/proc Threads)."
+      },
+      {
+        "title": "FD ouverts PHP",
+        "tip": "Agent PHP : nombre de descripteurs de fichiers ouverts du processus PHP parent (getppid()) (/proc/pid/fd)."
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.ja.json
@@ -358,6 +358,30 @@
           "ライブ",
           "利用可能"
         ]
+      },
+      {
+        "title": "PHP CPU 使用率",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) の CPU 使用率 (%)。/proc からサンプリング。"
+      },
+      {
+        "title": "PHP メモリ使用量",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) の実メモリ (MB, /proc の VmRSS)。"
+      },
+      {
+        "title": "PHP メモリピーク",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) のピーク実メモリ (MB, /proc の VmHWM)。"
+      },
+      {
+        "title": "PHP 仮想メモリ",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) の仮想メモリ (MB, /proc の VmSize)。"
+      },
+      {
+        "title": "PHP スレッド数",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) の OS スレッド数 (/proc の Threads)。"
+      },
+      {
+        "title": "PHP オープン FD 数",
+        "tip": "PHP エージェント：親 PHP プロセス (getppid()) のオープン file descriptor 数 (/proc/pid/fd)。"
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.ko.json
@@ -358,6 +358,30 @@
           "활성",
           "사용 가능"
         ]
+      },
+      {
+        "title": "PHP CPU 사용률",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) CPU 사용률 (%), /proc에서 샘플링."
+      },
+      {
+        "title": "PHP 메모리 사용량",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) 상주 메모리 (MB, /proc VmRSS)."
+      },
+      {
+        "title": "PHP 메모리 피크",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) 피크 상주 메모리 (MB, /proc VmHWM)."
+      },
+      {
+        "title": "PHP 가상 메모리",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) 가상 메모리 (MB, /proc VmSize)."
+      },
+      {
+        "title": "PHP 스레드 수",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) OS 스레드 수 (/proc Threads)."
+      },
+      {
+        "title": "PHP 열린 FD 수",
+        "tip": "PHP 에이전트: 부모 PHP 프로세스 (getppid()) 열린 file descriptor 수 (/proc/pid/fd)."
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.pt.json
@@ -364,6 +364,30 @@
           "vivos",
           "disponíveis"
         ]
+      },
+      {
+        "title": "Utilização de CPU PHP",
+        "tip": "Agente PHP: utilização de CPU (%) do processo PHP pai (getppid()), amostrada via /proc."
+      },
+      {
+        "title": "Memória PHP usada",
+        "tip": "Agente PHP: memória residente (MB) do processo PHP pai (getppid()) (/proc VmRSS)."
+      },
+      {
+        "title": "Pico de memória PHP",
+        "tip": "Agente PHP: pico de memória residente (MB) do processo PHP pai (getppid()) (/proc VmHWM)."
+      },
+      {
+        "title": "Memória virtual PHP",
+        "tip": "Agente PHP: memória virtual (MB) do processo PHP pai (getppid()) (/proc VmSize)."
+      },
+      {
+        "title": "Contagem de threads PHP",
+        "tip": "Agente PHP: contagem de threads OS do processo PHP pai (getppid()) (/proc Threads)."
+      },
+      {
+        "title": "FDs abertos PHP",
+        "tip": "Agente PHP: contagem de file descriptors abertos do processo PHP pai (getppid()) (/proc/pid/fd)."
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.zh-CN.json
@@ -201,6 +201,30 @@
       {
         "title": "Ruby Heap Slots",
         "expressionLabels": ["live", "available"]
+      },
+      {
+        "title": "PHP CPU 使用率",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) CPU 使用率 (%)，经 /proc 采样。"
+      },
+      {
+        "title": "PHP 内存使用",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) 常驻内存 (MB, /proc VmRSS)。"
+      },
+      {
+        "title": "PHP 内存峰值",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) 峰值常驻内存 (MB, /proc VmHWM)。"
+      },
+      {
+        "title": "PHP 虚拟内存",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) 虚拟内存 (MB, /proc VmSize)。"
+      },
+      {
+        "title": "PHP 线程数",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) OS 线程数 (/proc Threads)。"
+      },
+      {
+        "title": "PHP 打开 FD 数",
+        "tip": "PHP agent：父 PHP 进程 (getppid()) 打开的文件描述符数 (/proc/pid/fd)。"
       }
     ],
     "endpoint": [

--- a/apps/bff/src/bundled_templates/layers/general.json
+++ b/apps/bff/src/bundled_templates/layers/general.json
@@ -821,6 +821,70 @@
         "visibleWhen": { "kind": "mqe", "expression": "meter_instance_ruby_heap_live_slots_count", "op": "exists" },
         "span": 3,
         "rowSpan": 2
+      },
+      {
+        "id": "php_cpu",
+        "title": "PHP CPU Utilization",
+        "tip": "PHP agent: parent PHP process (getppid()) CPU utilization (%), sampled from /proc.",
+        "type": "line",
+        "unit": "%",
+        "expressions": ["meter_instance_php_process_cpu_utilization"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_process_cpu_utilization", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "php_mem",
+        "title": "PHP Memory Used",
+        "tip": "PHP agent: parent PHP process (getppid()) resident memory in MB (VmRSS from /proc).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_php_memory_used_mb"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_memory_used_mb", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "php_mem_peak",
+        "title": "PHP Memory Peak",
+        "tip": "PHP agent: parent PHP process (getppid()) peak resident memory in MB (VmHWM from /proc).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_php_memory_peak_mb"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_memory_peak_mb", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "php_vmsize",
+        "title": "PHP Virtual Memory",
+        "tip": "PHP agent: parent PHP process (getppid()) virtual memory in MB (VmSize from /proc).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_php_virtual_memory_mb"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_virtual_memory_mb", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "php_threads",
+        "title": "PHP Thread Count",
+        "tip": "PHP agent: OS thread count of the parent PHP process (getppid()) (Threads from /proc).",
+        "type": "line",
+        "expressions": ["meter_instance_php_thread_count"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_thread_count", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "php_open_fds",
+        "title": "PHP Open FDs",
+        "tip": "PHP agent: open file descriptor count of the parent PHP process (getppid()) (/proc/pid/fd).",
+        "type": "line",
+        "expressions": ["meter_instance_php_open_fd_count"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_php_open_fd_count", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
       }
     ],
     "endpoint": [


### PR DESCRIPTION
### Add PHP PHM instance dashboard widgets and i18n overlays

This PR adds **General Service → Instance** dashboard widgets for PHP PHM meters provided by the OAP `php-runtime` MAL analyzer.

Six line widgets, each gated with `visibleWhen` on the corresponding `meter_instance_php_*` MQE expression:

| Widget ID | Metric | Unit |
|-----------|--------|------|
| `php_cpu` | `meter_instance_php_process_cpu_utilization` | % |
| `php_mem` | `meter_instance_php_memory_used_mb` | MB |
| `php_mem_peak` | `meter_instance_php_memory_peak_mb` | MB |
| `php_vmsize` | `meter_instance_php_virtual_memory_mb` | MB |
| `php_threads` | `meter_instance_php_thread_count` | — |
| `php_open_fds` | `meter_instance_php_open_fd_count` | — |

Widget tips describe agent behavior: the parent PHP process is sampled via `getppid()` from `/proc`. Widgets stay hidden when no PHM data exists; JVM widgets remain unaffected via `visibleWhen`.

- [x] Update the documentation to include this new feature.
  - `CHANGELOG.md` under `## 1.1.0`
- [x] Tests are added to verify the new feature.
  - Bundled template: `apps/bff/src/bundled_templates/layers/general.json`
  - i18n overlays: `de`, `es`, `fr`, `ja`, `ko`, `pt`, `zh-CN`
  - Fork CI passed before opening ([fork run](https://github.com/songzhendong/skywalking-horizon-ui/actions/runs/28112206977))
- [ ] If it's UI related, attach the screenshots below.
  - _(attach General Service → Instance dashboard screenshots with PHM widgets visible)_

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGELOG`](https://github.com/apache/skywalking-horizon-ui/blob/main/CHANGELOG.md).
