### PR TITLE
feat: K8s Node "Pod Total" card and alarm-timeline range-select hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The version line is shared by every package in the monorepo (apps + shared packa
 
 ### Alarms
 
-- **The alarm timeline reads more clearly** — a clearer selection band and legend, and the detail sidebar reflows cleanly on narrow windows.
+- **The alarm timeline reads more clearly** — a clearer selection band and legend, and the detail sidebar reflows cleanly on narrow windows. Hovering the timeline now hints both affordances — click a minute to filter, or drag across the timeline to select a range — so range-selection is no longer hidden.
 
 ### User experience
 
@@ -45,6 +45,8 @@ The version line is shared by every package in the monorepo (apps + shared packa
 - **Cards can render values as colored status chips.** A card widget with `format: enum` now takes an optional chip color per value-map entry — `ok` (green), `warn` (amber), `err` (red), `info` (blue), `neutral` (grey) — and renders each matched value, or metric label, as a colored chip instead of a bare number. Set it in the layer-dashboard admin's value-map editor, next to the existing value → label mapping.
 
 - **The Kubernetes Node Status card now reads as a status, not a number.** Instead of a raw `1`, it shows the node's active conditions as colored chips — `Ready` in green, the `*Pressure` / `NetworkUnavailable` conditions in amber/red — so node health is legible at a glance.
+
+- **The Kubernetes Node dashboard gains a Pod Total card.** A compact card now sits directly under Node Status showing the current count of pods scheduled on the selected node (all phases) — the latest value of the same metric the "Pods on Node" trend already charts — so the space beside the status card is no longer blank.
 
 ## 1.0.0
 

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.de.json
@@ -194,6 +194,13 @@
         ]
       },
       {
+        "title": "Pods gesamt",
+        "tip": "Aktuell auf diesem Knoten eingeplante Pods (alle Phasen).",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "Knoten-CPU-Ressourcen",
         "expressions": [
           null,

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.es.json
@@ -130,6 +130,10 @@
         "tip": "Uso de CPU en millicores."
       },
       {
+        "title": "Total de pods",
+        "tip": "Pods actualmente programados en este nodo (todas las fases)."
+      },
+      {
         "title": "Recursos de CPU del nodo",
         "expressionLabels": [
           "total",

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.fr.json
@@ -132,6 +132,10 @@
         "tip": "Utilisation CPU en millicores."
       },
       {
+        "title": "Total pods",
+        "tip": "Pods actuellement planifiés sur ce nœud (toutes phases)."
+      },
+      {
         "title": "Ressources CPU du nœud",
         "expressionLabels": [
           "total",

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.ja.json
@@ -132,6 +132,10 @@
         "tip": "millicore 単位の CPU 使用量。"
       },
       {
+        "title": "Pod 合計",
+        "tip": "現在このノードにスケジュールされている Pod（全フェーズ）。"
+      },
+      {
         "title": "ノード CPU リソース",
         "expressionLabels": [
           "合計",

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.ko.json
@@ -132,6 +132,10 @@
         "tip": "밀리코어 단위의 CPU 사용량입니다."
       },
       {
+        "title": "Pod 총합",
+        "tip": "현재 이 노드에 스케줄된 Pod(모든 단계)."
+      },
+      {
         "title": "노드 CPU 리소스",
         "expressionLabels": [
           "전체",

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.pt.json
@@ -135,6 +135,10 @@
         "tip": "Uso de CPU em millicores."
       },
       {
+        "title": "Total de Pods",
+        "tip": "Pods atualmente agendados neste nó (todas as fases)."
+      },
+      {
         "title": "Recursos de CPU do nó",
         "expressionLabels": [
           "total",

--- a/apps/bff/src/bundled_templates/layers/k8s.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.i18n.zh-CN.json
@@ -73,6 +73,7 @@
       { "title": "节点状态" },
       { "title": "节点上的 Pod" },
       { "title": "节点 CPU 使用", "tip": "CPU 使用量，单位 millicore。" },
+      { "title": "Pod 总数", "tip": "当前调度到该节点的 Pod（所有阶段）。" },
       {
         "title": "节点 CPU 资源",
         "expressionLabels": ["total", "allocatable", "requests", "limits"]

--- a/apps/bff/src/bundled_templates/layers/k8s.json
+++ b/apps/bff/src/bundled_templates/layers/k8s.json
@@ -334,6 +334,18 @@
         "rowSpan": 2
       },
       {
+        "id": "node_pod_count",
+        "title": "Pod Total",
+        "tip": "Pods currently scheduled on this node (all phases).",
+        "type": "card",
+        "expressions": [
+          "latest(k8s_node_pod_total)"
+        ],
+        "span": 3,
+        "rowSpan": 1,
+        "format": "int"
+      },
+      {
         "id": "node_cpu_resources",
         "title": "Node CPU Resources",
         "type": "line",

--- a/apps/ui/src/components/charts/AlarmsTimeline.vue
+++ b/apps/ui/src/components/charts/AlarmsTimeline.vue
@@ -153,9 +153,11 @@ function buildOption(): echarts.EChartsCoreOption {
                  · <span style="color:#22c55e;">${recovered} recovered</span>
                </div>`
             : '',
-          total > 0
-            ? `<div style="margin-top:2px;font-size:10.5px;color:var(--sw-fg-3);">click to filter to this minute</div>`
-            : '',
+          `<div style="margin-top:2px;font-size:10.5px;color:var(--sw-fg-3);">${
+            total > 0
+              ? 'click to filter to this minute · drag to select a range'
+              : 'drag to select a range'
+          }</div>`,
         ].join('');
       },
     },

--- a/docs/dashboards/k8s.md
+++ b/docs/dashboards/k8s.md
@@ -88,6 +88,8 @@ For one selected node (an **Instance** in OAP terms) — its scheduling state an
 
 - **Pods on Node** — pods scheduled on the node over time (`k8s_node_pod_total`).
 
+- **Pod Total** — the current count of pods scheduled on the node, as a single latest reading (`latest(k8s_node_pod_total)`).
+
 - **Node CPU Usage** — node CPU usage in millicores (`k8s_node_cpu_usage`).
 
 - **Node CPU Resources** — node CPU total against allocatable, requests, and limits, in millicores (`k8s_node_cpu_cores`, `k8s_node_cpu_cores_allocatable`, `k8s_node_cpu_cores_requests`, `k8s_node_cpu_cores_limits`).


### PR DESCRIPTION
## Why

Two small operator-facing gaps on existing screens:

- On the **Kubernetes Node** dashboard, the Node Status card is a single-line `card` next to two-row charts, so the grid cell directly under it was left blank — wasted space on a dense observability page.
- On the **Alarms timeline**, you can drag to brush a time range, but nothing on screen tells you that — the affordance was undiscoverable (only "click to filter to this minute" was hinted).

## What

**K8s Node dashboard — new "Pod Total" card.**
A compact card now sits directly under Node Status showing the current count of pods scheduled on the node, `latest(k8s_node_pod_total)`. It back-fills the previously-blank grid cell (same span/row footprint as Node Status; the `grid-auto-flow: dense` layout drops it into the empty slot). The node scope has no Running-only pod metric (`k8s_node_pod_total` = `kube_pod_info.sum(['cluster','node'])`, all phases), so it is titled "Pod Total" and the tip says "all phases" — the latest value of the same series the existing "Pods on Node" trend charts. Title + tip added to the English source template and all seven locale overlays (zh-CN, de, es, fr, ja, ko, pt); positional overlay alignment preserved.

**Alarms timeline — range-select hint.**
The hover tooltip now surfaces both affordances: `click to filter to this minute · drag to select a range` over a populated bucket, and `drag to select a range` over an empty minute. No behavior change — only discoverability. (The tooltip strings in this component are hardcoded English today; the new hint matches that existing pattern. A full i18n pass on the component is a separate follow-up.)

Docs (`docs/dashboards/k8s.md`) and `CHANGELOG.md` updated.

## Validation

- **Preflight green:** `type-check` (vue-tsc + tsc, strict), `build-ui`, `build-bff`, `lint`, `test:unit` (162 BFF + 116 UI), `license:check`, and BFF `i18n:validate` (no overlay drift).
- **Live OAP (demo):** `latest(k8s_node_pod_total)` validated against the demo OAP on a real node — returns `SINGLE_VALUE` = 56 (matches the "Pods on Node" trend's last bucket), confirming the `card` widget type. The bundled K8s template + all 7 overlays were pushed to the demo OAP and re-fetched in live mode: the card renders at the right slot and localizes correctly (zh-CN "Pod 总数") with no positional shift in the other node widgets.
- **Alarms timeline** is a UI-only tooltip change (no OAP wire); verified the component hot-reloads and type-checks.