### PR TITLE
fix: pre-1.0 audit follow-ups — changelog consolidation, RBAC UI parity, 500 error-leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to Apache SkyWalking Horizon UI, written from the operator's poi
 
 The version line is shared by every package in the monorepo (apps + shared packages) plus the BFF's `HORIZON_VERSION` default.
 
-## 1.1.0
+## 1.0.0
 
 ### Deployment & configuration
 
@@ -23,10 +23,6 @@ The version line is shared by every package in the monorepo (apps + shared packa
 - **Network profiling picks its target instance in the create box and checks it has processes before you submit.** The create modal selects the instance inline and lists that instance's rover-monitored processes; if it has none, **Create** is blocked with a clear reason (OAP rejects a network task on a process-less instance) instead of failing after submit.
 
 - **pprof and async-profiling tasks open a detail modal with their captured logs.**
-
-### Logs
-
-- **Log and browser-error lists query on demand, not on every edit.** The per-layer Logs tab, cross-layer Log inspect, and the Browser Errors tab now stage condition changes and fetch only when you press **Run query** — a fresh tab shows a "Pick your conditions, then click Run query" prompt, and switching service resets to that prompt (clearing the level / tag / category filters), so the previous service's data never lingers under the new one.
 
 ### Alarms
 
@@ -48,8 +44,6 @@ The version line is shared by every package in the monorepo (apps + shared packa
 
 - **The Kubernetes Node dashboard gains a Pod Total card.** A compact card now sits directly under Node Status showing the current count of pods scheduled on the selected node (all phases) — the latest value of the same metric the "Pods on Node" trend already charts — so the space beside the status card is no longer blank.
 
-## 1.0.0
-
 ### Performance & behavior tuning
 
 - **New `performance` section in `horizon.yaml`.** Tune how hard the BFF fans metric queries out to OAP — per-route bulk (request) sizes and concurrency for the topology, 3D-map, landing, and dashboard fan-outs — plus protective caps: the service-map render valve (`topologyMaxNodes` / `topologyMaxEdges`) and per-request record caps for traces / logs / browser logs. Operational, hot-reloaded, per-deployment; defaults match the previous built-in values, so the whole block is optional. Raise it for a beefy OAP + storage backend, lower it to protect a modest deployment; every value clamps to a hard ceiling.
@@ -65,6 +59,7 @@ The version line is shared by every package in the monorepo (apps + shared packa
 
 ### Logs
 
+- **Log and browser-error lists query on demand, not on every edit.** The per-layer Logs tab, cross-layer Log inspect, and the Browser Errors tab now stage condition changes and fetch only when you press **Run query** — a fresh tab shows a "Pick your conditions, then click Run query" prompt, and switching service resets to that prompt (clearing the level / tag / category filters), so the previous service's data never lingers under the new one.
 - **Log inspect uses the full width.** The cross-layer Log inspect form (Target + Tags / Trace ID / Time / Limit conditions) now spans the whole page instead of sharing a two-column strip with empty space.
 - **Clicking a log row opens a centered popout.** Both the cross-layer Log inspect and the per-layer Logs tab now open the same full-payload popout on row click — format-aware pretty-print (JSON pretty-printed by content type), the tags table, service / instance / endpoint / time meta, a copy button, and the trace link. Escape or the close button dismisses it.
 - **Log inspect can now query Browser errors across the page.** A new **Browser** source on Log inspect (beside Raw) queries the BROWSER layer's JS error logs from anywhere — pick a browser service or type a service name (or leave it blank for all services), then narrow by category (AJAX / RESOURCE / VUE / PROMISE / JS / UNKNOWN), version, page, and time window, and read the error list (message, category, page path, app version, time, minified `line:col`). Upload and manage source maps inline, then click a row to open a popout with the error meta, the raw stack, and the source-map de-obfuscation control — resolve the minified stack back to the original frames + source snippet.

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -151,13 +151,21 @@ source.onChange((cfg) => {
 
 const app = Fastify({ logger: loggerOptions });
 
-app.setErrorHandler((err, _req, reply) => {
+app.setErrorHandler((err, req, reply) => {
   if (err instanceof HttpError) {
     return reply.status(err.statusCode).send({ code: err.code, message: err.message, details: err.details });
   }
-  const message = err instanceof Error ? err.message : 'internal error';
+  // Never leak an internal / upstream exception message to the client — it can
+  // carry upstream response snippets or endpoint details. Log it server-side,
+  // return a generic body plus the request id for correlation; dev keeps the
+  // raw message for debugging.
   reply.log.error({ err }, 'unhandled');
-  return reply.status(500).send({ code: 'internal_error', message });
+  const isDev = process.env.NODE_ENV === 'development';
+  return reply.status(500).send({
+    code: 'internal_error',
+    message: isDev && err instanceof Error ? err.message : 'internal error',
+    requestId: req.id,
+  });
 });
 
 // Baseline security headers on every response (MIME-sniff / clickjacking /

--- a/apps/ui/src/state/auth.ts
+++ b/apps/ui/src/state/auth.ts
@@ -77,14 +77,19 @@ export const useAuthStore = defineStore('auth', () => {
     user.value = null;
   }
 
+  // Mirrors the BFF's matchOne (apps/bff/src/rbac/verbs.ts) exactly. This UI gate
+  // is advisory — the BFF enforces — but it must agree, or it hides custom `admin`
+  // grants and shows three-segment controls (e.g. rule:write:structural) that a
+  // two-segment grant like `*:write` does not actually carry and the BFF denies.
   function hasVerb(verb: string): boolean {
     const grants = user.value?.verbs ?? [];
     for (const g of grants) {
-      if (g === '*' || g === verb) return true;
-      const [ga, gact] = g.split(':', 2);
-      const [ra, ract] = verb.split(':', 2);
-      if (gact === '*' && ga === ra) return true;
-      if (ga === '*' && gact === ract) return true;
+      if (g === '*' || g === 'admin' || g === verb) return true;
+      const [ga, gact, gsub] = g.split(':', 3);
+      const [ra, ract, rsub] = verb.split(':', 3);
+      if (ga === ra && gact === '*') return true;
+      if (ga === '*' && gact === ract && (gsub ?? '') === (rsub ?? '')) return true;
+      if (ga === ra && gact === ract && (gsub ?? '') === (rsub ?? '')) return true;
     }
     return false;
   }


### PR DESCRIPTION
## Why

A pre-1.0 audit flagged several items; this PR lands the three that are clear, no-decision fixes. The remaining audit items (dependency-override strategy, login throttling, CI audit gating, the version line itself) are deferred by maintainer decision.

## What

**Changelog (docs).** 1.0.0 isn't released yet (latest tag v0.7.0; package.json `1.0.0-dev`), but the changelog had a populated `## 1.1.0` section stacked above `## 1.0.0` — wrong, since all of it ships in 1.0.0. Merged into a single unreleased `## 1.0.0` (the duplicated `### Logs` subsection merged; every bullet preserved). This also stops `release.sh` from duplicating the `1.1.0` heading on the next-dev bump after a 1.0.0 cut.

**RBAC UI matcher parity (fix).** The UI auth store's verb matcher diverged from the BFF's `rbac/matchOne` — it ignored the `admin` sentinel and truncated verbs to two segments. So a custom `admin` grant was hidden in the UI, and a `*:write` grant displayed `rule:write:structural` controls the BFF then denies. The UI matcher now mirrors `matchOne` exactly (admin sentinel, `split(':', 3)`, sub-action equality). The UI gate is advisory — the BFF still enforces — so this is a UX-correctness fix.

**500 error-leak (fix).** The global Fastify error handler returned raw `err.message` to the client for every non-`HttpError` 500 (which can carry upstream response snippets / endpoint details). It now logs server-side and returns a generic body + `requestId` for correlation; `err.message` is kept only in `NODE_ENV=development`. `HttpError` messages (intentionally client-facing) are unchanged.

## Validation

Green: type-check (both workspaces), build-ui, build-bff, lint + source-budget, 116 UI + 162 BFF unit tests (the RBAC verb suite among them — the UI matcher now mirrors it), license 0-invalid.

Coverage note: the 500 path and the `admin` / `structural` verb cases aren't exercisable on the demo's simple roles, so those are covered by type-check + the BFF verb suite rather than a live click-through; the changelog change is content-only. No OAP wire shape is touched.