### PR TITLE
fix(traces,logs): custom time range uses absolute epoch-ms (timezone-correct)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The version line is shared by every package in the monorepo (apps + shared packa
 
 ## 1.0.0
 
+### Traces & logs
+
+- **Custom time ranges on the Traces and Logs tabs now return results when your browser and the OAP server sit in different timezones.** A custom range (and the metric→trace drill's centered window) was sent as a browser-local wall-clock string that the server re-read in its own timezone — so on a UTC-container deployment the window shifted by your UTC offset and came back empty, while the rolling presets kept working. Both paths now send absolute timestamps and the server applies the OAP timezone offset, consistent with every other query surface.
+
 ### Deployment & configuration
 
 - **Run on the bundled templates, read-only — no OAP ui_template API needed.** A new `templates.mode` setting (`HORIZON_TEMPLATES_MODE`) adds a `readonly` mode: Horizon renders every dashboard / overview / alert-page / 3D-map / translation from the **local bundle** and never calls OAP's ui_template admin API. The whole config surface goes **read-only** — the admin pages still open and show the bundled config, but editing and publishing are disabled (and the BFF rejects a write even if it's fired directly). OAP's **query** API is still used and health-checked, so metrics / traces / logs / topology work exactly as before; only the config-template store is local. Default stays `live` (seed-to-OAP, editable). The Cluster Status page shows the active mode and ui_template availability.

--- a/apps/bff/src/http/query/explore.ts
+++ b/apps/bff/src/http/query/explore.ts
@@ -74,10 +74,10 @@ function resolveNativeEntity(e: ExploreEntity): {
 }
 
 /** Explicit epoch-ms window overrides the rolling minutes; trace.ts reads
- *  `start`/`end` as ISO and `windowMinutes` as the fallback. */
-function traceWindowFields(w: ExploreWindow): Pick<TraceListBody, 'windowMinutes' | 'start' | 'end'> {
+ *  `startMs`/`endMs` and `windowMinutes` as the fallback. */
+function traceWindowFields(w: ExploreWindow): Pick<TraceListBody, 'windowMinutes' | 'startMs' | 'endMs'> {
   if (typeof w.startMs === 'number' && typeof w.endMs === 'number' && w.endMs > w.startMs) {
-    return { start: new Date(w.startMs).toISOString(), end: new Date(w.endMs).toISOString() };
+    return { startMs: w.startMs, endMs: w.endMs };
   }
   return { windowMinutes: w.windowMinutes };
 }

--- a/apps/bff/src/http/query/log.ts
+++ b/apps/bff/src/http/query/log.ts
@@ -67,20 +67,22 @@ function clampPageSize(requested: number | undefined, fallback: number, max: num
  *  round off the most recent log lines for up to a minute, which is
  *  exactly when an operator is triaging.
  *
- *  Three input shapes:
- *    - explicit MINUTE form `YYYY-MM-DD HHmm` (legacy UI custom-range) —
- *      padded to seconds with `00`. The UI emits these in its current TZ;
- *      OAP reads them in OAP-TZ. (Same convention as booster-ui.)
- *    - explicit SECOND form `YYYY-MM-DD HHmmss` — forwarded verbatim.
- *    - no explicit form → rolling fallback, formatted OAP-local at
- *      SECOND precision using the cached server offset. */
+ *  Two shapes: an explicit absolute window (epoch ms) formatted OAP-local
+ *  via `fmtSecond`, or a rolling fallback in minutes ending at "now". */
 function defaultWindow(
   offsetMinutes: number,
   minutes?: number,
-  explicit?: { startTime?: string; endTime?: string },
+  explicit?: { startMs?: number; endMs?: number },
 ): { start: string; end: string } {
-  if (explicit?.startTime && explicit.endTime) {
-    return { start: toSecond(explicit.startTime), end: toSecond(explicit.endTime) };
+  if (
+    typeof explicit?.startMs === 'number' &&
+    typeof explicit.endMs === 'number' &&
+    explicit.startMs < explicit.endMs
+  ) {
+    return {
+      start: fmtSecond(explicit.startMs, offsetMinutes),
+      end: fmtSecond(explicit.endMs, offsetMinutes),
+    };
   }
   const m = Number.isFinite(minutes) && (minutes as number) > 0
     ? Math.min(60 * 24 * 7, Math.round(minutes as number))
@@ -88,12 +90,6 @@ function defaultWindow(
   const endMs = Date.now();
   const startMs = endMs - m * 60_000;
   return { start: fmtSecond(startMs, offsetMinutes), end: fmtSecond(endMs, offsetMinutes) };
-}
-
-function toSecond(s: string): string {
-  // Pad MINUTE-precision strings ("YYYY-MM-DD HHmm") to seconds. Pass
-  // SECOND-precision strings through unchanged.
-  return /\s\d{4}$/.test(s) ? `${s}00` : s;
 }
 
 const LIST_SERVICES_FOR_RESOLVE = /* GraphQL */ `
@@ -263,8 +259,8 @@ export function registerLogRoute(app: FastifyInstance, deps: LogRouteDeps): void
       const opts = buildOapOpts(deps.config.current, deps.fetch);
       const offset = await getServerOffsetMinutes(deps.config, deps.fetch);
       const window = defaultWindow(offset, body.windowMinutes, {
-        startTime: body.startTime,
-        endTime: body.endTime,
+        startMs: body.startMs,
+        endMs: body.endMs,
       });
 
       // Resolve a service NAME to an id if the caller used one.
@@ -328,8 +324,8 @@ export function registerLogRoute(app: FastifyInstance, deps: LogRouteDeps): void
       const opts = buildOapOpts(deps.config.current, deps.fetch);
       const offset = await getServerOffsetMinutes(deps.config, deps.fetch);
       const window = defaultWindow(offset, body.windowMinutes, {
-        startTime: body.startTime,
-        endTime: body.endTime,
+        startMs: body.startMs,
+        endMs: body.endMs,
       });
       let serviceId = body.serviceId ?? null;
       if (!serviceId && body.service) {

--- a/apps/bff/src/http/query/trace.ts
+++ b/apps/bff/src/http/query/trace.ts
@@ -93,16 +93,12 @@ function rollingWindow(minutes: number, offsetMinutes: number): { start: string;
   return { start: fmtSecond(startMs, offsetMinutes), end: fmtSecond(endMs, offsetMinutes) };
 }
 function explicitWindow(
-  startIso: string,
-  endIso: string,
+  startMs: number,
+  endMs: number,
   offsetMinutes: number,
 ): { start: string; end: string } | null {
-  const s = new Date(startIso);
-  const e = new Date(endIso);
-  if (!Number.isFinite(s.getTime()) || !Number.isFinite(e.getTime()) || e.getTime() < s.getTime()) {
-    return null;
-  }
-  return { start: fmtSecond(s.getTime(), offsetMinutes), end: fmtSecond(e.getTime(), offsetMinutes) };
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return null;
+  return { start: fmtSecond(startMs, offsetMinutes), end: fmtSecond(endMs, offsetMinutes) };
 }
 
 export interface TraceListBody {
@@ -123,11 +119,10 @@ export interface TraceListBody {
   tags?: Array<{ key: string; value: string }>;
   /** Rolling window in minutes. Default 30; clamped to [1, 10080]. */
   windowMinutes?: number;
-  /** Explicit ISO start (UTC). When both `start` and `end` are
-   *  provided they override `windowMinutes`. */
-  start?: string;
-  /** Explicit ISO end (UTC). Pair with `start`. */
-  end?: string;
+  /** Explicit absolute epoch ms. When both are set they override
+   *  `windowMinutes`; the BFF applies the OAP offset. */
+  startMs?: number;
+  endMs?: number;
   /** Admin Preview: the operator's draft `traces` block (JSON string).
    *  When present + valid, it picks the source instead of the remote
    *  template — same preview path as topology / endpoint-dependency. */
@@ -300,7 +295,10 @@ export async function fetchNativeList(
   const api = await detectTraceQueryApi(opts);
   // Explicit start+end takes precedence over windowMinutes; falling
   // back to the rolling default when the explicit range is invalid.
-  const explicit = body.start && body.end ? explicitWindow(body.start, body.end, offsetMinutes) : null;
+  const explicit =
+    typeof body.startMs === 'number' && typeof body.endMs === 'number'
+      ? explicitWindow(body.startMs, body.endMs, offsetMinutes)
+      : null;
   const window = explicit ?? rollingWindow(body.windowMinutes ?? DEFAULT_WINDOW_MIN, offsetMinutes);
   let serviceId: string | null = null;
   try {

--- a/apps/ui/src/api/scopes/trace.ts
+++ b/apps/ui/src/api/scopes/trace.ts
@@ -45,8 +45,8 @@ export class TraceApi {
       pageSize?: number;
       tags?: Array<{ key: string; value: string }>;
       windowMinutes?: number;
-      start?: string;
-      end?: string;
+      startMs?: number;
+      endMs?: number;
       /** Admin preview: the operator's draft `traces` block (JSON string). */
       previewConfig?: string;
     } = {},

--- a/apps/ui/src/layer/logs/LayerLogsView.vue
+++ b/apps/ui/src/layer/logs/LayerLogsView.vue
@@ -182,8 +182,8 @@ const {
   customStart,
   customEnd,
   isCustomRange,
-  startTime: startTimeRef,
-  endTime: endTimeRef,
+  startMs: startMsRef,
+  endMs: endMsRef,
   windowMinutesEffective,
 } = useLogTimeRange(30);
 
@@ -205,8 +205,8 @@ interface AppliedLogConditions {
   keywords: string[];
   tags: LogTagFilter[];
   windowMinutes: number;
-  startTime: string | null;
-  endTime: string | null;
+  startMs: number | null;
+  endMs: number | null;
 }
 function snapshotConditions(): AppliedLogConditions {
   return {
@@ -217,8 +217,8 @@ function snapshotConditions(): AppliedLogConditions {
     keywords: keywordsRef.value,
     tags: allTags.value,
     windowMinutes: windowMinutesEffective.value,
-    startTime: startTimeRef.value,
-    endTime: endTimeRef.value,
+    startMs: startMsRef.value,
+    endMs: endMsRef.value,
   };
 }
 const applied = ref<AppliedLogConditions>(snapshotConditions());
@@ -246,8 +246,8 @@ const aTraceId = computed(() => applied.value.traceId);
 const aKeywords = computed(() => applied.value.keywords);
 const aTags = computed(() => applied.value.tags);
 const aWindowMinutes = computed(() => applied.value.windowMinutes);
-const aStartTime = computed(() => applied.value.startTime);
-const aEndTime = computed(() => applied.value.endTime);
+const aStartMs = computed(() => applied.value.startMs);
+const aEndMs = computed(() => applied.value.endMs);
 
 const { logs, total, isFetching, error, refetch } = useLayerLogs(layerKey, {
   service: aService,
@@ -259,8 +259,8 @@ const { logs, total, isFetching, error, refetch } = useLayerLogs(layerKey, {
   page,
   pageSize,
   windowMinutes: aWindowMinutes,
-  startTime: aStartTime,
-  endTime: aEndTime,
+  startMs: aStartMs,
+  endMs: aEndMs,
   enabled: hasQueried,
 });
 
@@ -271,8 +271,8 @@ const { facets, refetch: refetchFacets } = useLayerLogFacets(layerKey, {
   traceId: aTraceId,
   keywords: aKeywords,
   windowMinutes: aWindowMinutes,
-  startTime: aStartTime,
-  endTime: aEndTime,
+  startMs: aStartMs,
+  endMs: aEndMs,
   enabled: hasQueried,
 });
 

--- a/apps/ui/src/layer/logs/useLayerLogs.ts
+++ b/apps/ui/src/layer/logs/useLayerLogs.ts
@@ -30,8 +30,8 @@ export interface LogListParams {
   page: Ref<number>;
   pageSize: Ref<number>;
   windowMinutes?: Ref<number>;
-  startTime?: Ref<string | null>;
-  endTime?: Ref<string | null>;
+  startMs?: Ref<number | null>;
+  endMs?: Ref<number | null>;
   /** Gate the query — when false it never runs. Manual-fire pages hold it
    *  until the operator presses Run query. Defaults to always-on. */
   enabled?: Ref<boolean>;
@@ -51,8 +51,8 @@ export function useLayerLogs(layerKey: Ref<string>, params: LogListParams) {
       params.page,
       params.pageSize,
       params.windowMinutes ?? computed(() => 0),
-      params.startTime ?? computed(() => null),
-      params.endTime ?? computed(() => null),
+      params.startMs ?? computed(() => null),
+      params.endMs ?? computed(() => null),
     ],
     queryFn: () =>
       bffClient.log.list(layerKey.value, {
@@ -63,8 +63,8 @@ export function useLayerLogs(layerKey: Ref<string>, params: LogListParams) {
         ...(params.keywords.value.length > 0 ? { keywordsOfContent: params.keywords.value } : {}),
         ...(params.tags.value.length > 0 ? { tags: params.tags.value } : {}),
         ...(params.windowMinutes?.value ? { windowMinutes: params.windowMinutes.value } : {}),
-        ...(params.startTime?.value && params.endTime?.value
-          ? { startTime: params.startTime.value, endTime: params.endTime.value }
+        ...(params.startMs?.value && params.endMs?.value
+          ? { startMs: params.startMs.value, endMs: params.endMs.value }
           : {}),
         page: params.page.value,
         pageSize: params.pageSize.value,
@@ -97,8 +97,8 @@ export interface LogFacetParams {
   traceId: Ref<string | null>;
   keywords: Ref<string[]>;
   windowMinutes?: Ref<number>;
-  startTime?: Ref<string | null>;
-  endTime?: Ref<string | null>;
+  startMs?: Ref<number | null>;
+  endMs?: Ref<number | null>;
   enabled?: Ref<boolean>;
 }
 
@@ -113,8 +113,8 @@ export function useLayerLogFacets(layerKey: Ref<string>, params: LogFacetParams)
       params.traceId,
       params.keywords,
       params.windowMinutes ?? computed(() => 0),
-      params.startTime ?? computed(() => null),
-      params.endTime ?? computed(() => null),
+      params.startMs ?? computed(() => null),
+      params.endMs ?? computed(() => null),
     ],
     queryFn: () =>
       bffClient.log.facets(layerKey.value, {
@@ -124,8 +124,8 @@ export function useLayerLogFacets(layerKey: Ref<string>, params: LogFacetParams)
         ...(params.traceId.value ? { traceId: params.traceId.value } : {}),
         ...(params.keywords.value.length > 0 ? { keywordsOfContent: params.keywords.value } : {}),
         ...(params.windowMinutes?.value ? { windowMinutes: params.windowMinutes.value } : {}),
-        ...(params.startTime?.value && params.endTime?.value
-          ? { startTime: params.startTime.value, endTime: params.endTime.value }
+        ...(params.startMs?.value && params.endMs?.value
+          ? { startMs: params.startMs.value, endMs: params.endMs.value }
           : {}),
         sampleSize: 200,
       }),

--- a/apps/ui/src/layer/logs/useLogTimeRange.ts
+++ b/apps/ui/src/layer/logs/useLogTimeRange.ts
@@ -23,11 +23,10 @@
  * dropdown for two `datetime-local` inputs (cap is 7 days, enforced
  * server-side too). Mirrors the trace tab's Custom… escape hatch.
  *
- * Exposes the OAP-shaped query refs the log/facet composables consume:
+ * Exposes the query refs the log/facet composables consume:
  *   - `windowMinutesEffective` — preset minutes, or 0 in custom mode.
- *   - `startTime`/`endTime` — `YYYY-MM-DD HHmm` (OAP minute) in custom
- *     mode, else null. The BFF forwards these to the same
- *     `queryDuration.start/end` slot the trace tab uses.
+ *   - `startMs`/`endMs` — absolute epoch ms in custom mode, else null.
+ *     The BFF applies the OAP offset (same as the trace tab).
  */
 
 import { computed, ref, watch, type ComputedRef, type Ref } from 'vue';
@@ -48,23 +47,13 @@ function fmtDateTimeLocal(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-/** OAP wants `YYYY-MM-DD HHmm`; the native `datetime-local` input
- *  emits `YYYY-MM-DDTHH:MM`. Convert so the BFF can forward to the
- *  same `queryDuration.start/end` slot the trace tab uses. */
-function toOapMinute(local: string | null): string | null {
-  if (!local) return null;
-  const [d, t] = local.split('T');
-  if (!d || !t) return null;
-  return `${d} ${t.replace(':', '')}`;
-}
-
 export interface LogTimeRange {
   windowMinutes: Ref<number>;
   customStart: Ref<string | null>;
   customEnd: Ref<string | null>;
   isCustomRange: ComputedRef<boolean>;
-  startTime: ComputedRef<string | null>;
-  endTime: ComputedRef<string | null>;
+  startMs: ComputedRef<number | null>;
+  endMs: ComputedRef<number | null>;
   windowMinutesEffective: ComputedRef<number>;
 }
 
@@ -88,11 +77,11 @@ export function useLogTimeRange(initialMinutes = 30): LogTimeRange {
     }
   });
 
-  const startTime = computed<string | null>(() =>
-    isCustomRange.value ? toOapMinute(customStart.value) : null,
+  const startMs = computed<number | null>(() =>
+    isCustomRange.value && customStart.value ? new Date(customStart.value).getTime() : null,
   );
-  const endTime = computed<string | null>(() =>
-    isCustomRange.value ? toOapMinute(customEnd.value) : null,
+  const endMs = computed<number | null>(() =>
+    isCustomRange.value && customEnd.value ? new Date(customEnd.value).getTime() : null,
   );
   const windowMinutesEffective = computed<number>(() =>
     isCustomRange.value ? 0 : windowMinutes.value,
@@ -103,8 +92,8 @@ export function useLogTimeRange(initialMinutes = 30): LogTimeRange {
     customStart,
     customEnd,
     isCustomRange,
-    startTime,
-    endTime,
+    startMs,
+    endMs,
     windowMinutesEffective,
   };
 }

--- a/apps/ui/src/layer/traces/useLayerTraces.ts
+++ b/apps/ui/src/layer/traces/useLayerTraces.ts
@@ -98,7 +98,12 @@ export function useLayerTraces(layerKey: Ref<string>, params: TraceListParams) {
         pageSize: params.pageSize.value,
         ...(params.tags.value.length > 0 ? { tags: params.tags.value } : {}),
         ...(params.customStart.value && params.customEnd.value
-          ? { start: params.customStart.value, end: params.customEnd.value }
+          ? // datetime-local is browser-local; send absolute epoch ms so the BFF
+            // applies the OAP offset — same as every other query surface.
+            {
+              startMs: new Date(params.customStart.value).getTime(),
+              endMs: new Date(params.customEnd.value).getTime(),
+            }
           : { windowMinutes: params.windowMinutes.value }),
         ...(previewCfg.value ? { previewConfig: previewCfg.value } : {}),
       }),

--- a/packages/api-client/src/logs.ts
+++ b/packages/api-client/src/logs.ts
@@ -66,13 +66,12 @@ export interface LogQueryRequest {
   pageSize?: number;
   /** Rolling time-window for the query in minutes, ending at "now".
    *  Falls back to the BFF default (~60min) when omitted. Ignored when
-   *  an explicit `startTime` / `endTime` pair is supplied. */
+   *  an explicit `startMs` / `endMs` pair is supplied. */
   windowMinutes?: number;
-  /** Explicit absolute window — `YYYY-MM-DD HHmm` (OAP minute-step
-   *  format). When both `startTime` + `endTime` are set, the rolling
-   *  `windowMinutes` is ignored. */
-  startTime?: string;
-  endTime?: string;
+  /** Explicit absolute window in epoch ms. When both are set the rolling
+   *  `windowMinutes` is ignored; the BFF applies the OAP offset. */
+  startMs?: number;
+  endMs?: number;
 }
 
 export interface LogsResponse {


### PR DESCRIPTION
## Why

Reported on [apache/skywalking#13934](https://github.com/apache/skywalking/discussions/13934): a **custom** time range on the Traces tab returned no results, while "recent" worked. Root cause is a timezone bug — the custom range was sent as a browser-local **wall-clock string** the server re-read in its own timezone, so on a UTC-container deployment (browser ≠ server TZ) the window shifted by the UTC offset and landed on a time with no data. It reproduces only when browser and server timezones differ (so it looked fine in same-machine local dev).

An audit of every custom-range surface found the same class of bug in **two** places, and confirmed the other six are already tz-proof:

| Surface | Was | Now |
|---|---|---|
| Native traces | ❌ wall-clock string → `new Date()` in server TZ | ✅ epoch-ms → `fmtSecond` |
| Layer logs | ❌ browser-local minute string → passthrough to OAP | ✅ epoch-ms → `fmtSecond` |
| Zipkin, browser errors/logs, operate inspect, events, alarms, global picker, profiling | ✅ already absolute (epoch-ms / lookback) | unchanged |

## What

Both buggy paths now send **absolute epoch ms** (`startMs`/`endMs`) and the BFF converts to OAP-server-local via `fmtSecond(ms, offset)` — the exact pattern the tz-proof surfaces already use. One consistent, timezone-proof way everywhere, no exceptions.

- **Native traces** — `useLayerTraces` sends `startMs`/`endMs`; BFF `TraceListBody`/`explicitWindow`/`fetchNativeList` take epoch ms.
- **Layer logs** — `LogQueryRequest`, `useLogTimeRange` (drops `toOapMinute`), `useLayerLogs`, `LayerLogsView`, and BFF `defaultWindow` all move to `startMs`/`endMs` + `fmtSecond`.
- **Operate trace-inspect** (`explore.ts`) — drops its now-redundant `.toISOString()` round-trip and passes the epoch ms straight through.
- The **metric→trace drill** rides the same trace send path, so its centered window is fixed by the same change.

## Validation

`type-check`, `lint`, `build`, unit tests (BFF 172, UI 133) all green. The tz mismatch can't be reproduced in same-machine local dev; the fix is verified by construction (absolute instant → `fmtSecond(ms, serverOffset)`, identical to the browser-errors/events/alarms surfaces the audit confirmed correct). Worth a deployed smoke-check with browser TZ ≠ OAP TZ.