### PR TITLE
ci: one job for every build and check, plus an end-to-end suite against a real OAP

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,9 +39,10 @@ github:
       required_status_checks:
         # Require branches to be up to date with main before merging.
         strict: true
-        # The CI "required" job rolls up every check (license-header,
-        # dependency-license, type-check, build-ui, build-bff, test) into a
-        # single "Required" status, so protection gates on one context.
+        # The CI "required" job rolls up every check (license-header plus the
+        # build-and-check job that lints, type-checks, tests, packages and
+        # boots the artifact) into a single "Required" status, so protection
+        # gates on one context.
         contexts:
           - Required
       required_pull_request_reviews:

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -47,8 +47,8 @@ operate it; never internal code narration). Flat layout, registered in
 `docs/menu.yml`. Same one-line-per-paragraph house style.
 
 ### C. Compiling passed (type-check + build)
-This is what "compiling passed" means here — CI runs `type-check`, `build-ui`,
-`build-bff` as separate gates:
+This is what "compiling passed" means here — CI type-checks, then builds both
+apps as part of `pnpm package`:
 
 ```bash
 pnpm -r run type-check                              # vue-tsc + tsc, strict, no `any`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ concurrency:
 
 jobs:
   license-header:
+    # Kept separate because it needs neither Node nor `pnpm install` — it is a
+    # container action that would otherwise sit behind the toolchain setup the
+    # build job spends its first half-minute on.
     name: License header
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -38,19 +41,15 @@ jobs:
       - name: Check license header
         uses: apache/skywalking-eyes@5b7ee1731d036b5aac68f8bd3fc9e6f98ada082e
 
-  dependency-license:
-    # The binary tarball bundles the full production dependency tree — the
-    # BFF runtime deps (dist/node_modules) AND the UI deps Vite compiles
-    # into the static bundle — so ASF policy requires every one of their
-    # licenses reproduced in the binary LICENSE/NOTICE.
-    # collect-dist-licenses.mjs enumerates that tree straight from the pnpm
-    # store (no `pnpm package` needed), and this job fails if either:
-    #   1. a dep carries a Category-X / unknown license (check-dist-licenses), or
-    #   2. the committed binary LICENSE/NOTICE reference is stale (--check) —
-    #      i.e. prod deps changed without `pnpm licenses:bin:update`.
-    name: Dependency license
+  build-and-check:
+    # Every Node-side gate in one job. They all need the same checkout + pnpm
+    # install, and each gate itself finishes in seconds, so fanning them across
+    # runners bought a few tens of seconds of wall clock at the price of paying
+    # the setup cost eight times over. Steps run cheapest-first so a lint or
+    # type error reports before the package build starts.
+    name: Build and check
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -61,8 +60,57 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+
+      # ESLint (rules + 2000-line cap, comments excluded) across ui + bff, the
+      # source-budget gate (≤2000 code / ≤500 comment lines per file), both
+      # i18n gates (UI catalog coverage/parity and the BFF template-overlay
+      # validator), and the bundled layer / overview templates. Those templates
+      # are configuration that ships inside the release, so a broken one is a
+      # shipping defect rather than operator error — and the loader only
+      # JSON.parses them, which is how an orderBy naming a nonexistent column
+      # and an unsupported aggregation both shipped.
+      - name: Lint, source budget, i18n, bundled templates
+        run: pnpm lint
+
+      - name: Type-check
+        run: pnpm -r run type-check
+
+      # `pnpm -r` walks every workspace package and runs `test:unit` —
+      # currently @skywalking-horizon-ui/ui (vitest + jsdom),
+      # @skywalking-horizon-ui/bff and @skywalking-horizon-ui/api-client
+      # (vitest, node env). Packages without the script (design-tokens,
+      # templates) are skipped automatically.
+      # The scripts already include `vitest run`, so no `--run` forwarding
+      # needed — keeps the CI line robust against pnpm-flag parsing quirks.
+      # The runner pool is pinned in those same scripts, not on this line, so a
+      # contributor's `pnpm test:unit` and this job share one isolation model.
+      # Why `threads`, and what enforces it: `src/runner-pool.test.ts`.
+      - name: Unit tests
+        run: pnpm -r run test:unit
+
+      # ASSEMBLES the distributable: the three packages/* builds, the BFF
+      # esbuild bundle, the Vite UI build, dist/server.js, the built UI at
+      # dist/static/, bundled templates, i18n catalogs, AI resources. Because it
+      # compiles the UI and the BFF on the way, it subsumes standalone build
+      # steps. Until this ran in CI the assembly happened for the first time
+      # inside the release image build — i.e. after merge — so a broken tarball
+      # merged green.
+      - name: Package the distributable
+        run: pnpm package
+
+      # After `pnpm package`, never before: collect-dist-licenses writes its
+      # LICENSE / NOTICE / report into dist/, and packaging starts by wiping
+      # that directory.
+      # The binary tarball bundles the full production dependency tree — the
+      # BFF runtime deps (dist/node_modules) AND the UI deps Vite compiles into
+      # the static bundle — so ASF policy requires every one of their licenses
+      # reproduced in the binary LICENSE/NOTICE. This fails if either:
+      #   1. a dep carries a Category-X / unknown license (check-dist-licenses), or
+      #   2. the committed binary LICENSE/NOTICE reference is stale (--check) —
+      #      i.e. prod deps changed without `pnpm licenses:bin:update`.
       - name: Verify binary LICENSE/NOTICE (drift + ASF allow/deny)
         run: pnpm licenses:bin:check
+
       - name: Compare source vs. binary LICENSE/NOTICE shape
         run: |
           # Source-flavored LICENSE = repo root; must NOT contain the
@@ -82,6 +130,7 @@ jobs:
           head -1 NOTICE | grep -q 'Apache SkyWalking Horizon UI'
           head -1 dist-material/release-docs/NOTICE | grep -q 'Apache SkyWalking Horizon UI'
           echo "src/bin LICENSE+NOTICE shape OK."
+
       - name: Upload dependency report
         uses: actions/upload-artifact@v4
         with:
@@ -91,146 +140,7 @@ jobs:
             dist/NOTICE
             dist/.dependency-report.json
 
-  type-check:
-    name: Type-check (workspaces)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm -r run type-check
-
-  build-ui:
-    name: Build · @skywalking-horizon-ui/ui
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @skywalking-horizon-ui/ui build
-
-  build-bff:
-    name: Build · @skywalking-horizon-ui/bff
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @skywalking-horizon-ui/bff build
-
-  test:
-    name: Unit tests (workspaces)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      # `pnpm -r` walks every workspace package and runs `test:unit` —
-      # currently @skywalking-horizon-ui/ui (vitest + jsdom),
-      # @skywalking-horizon-ui/bff and @skywalking-horizon-ui/api-client
-      # (vitest, node env). Packages without the script (design-tokens,
-      # templates) are skipped automatically.
-      # The scripts already include `vitest run`, so no `--run` forwarding
-      # needed — keeps the CI line robust against pnpm-flag parsing quirks.
-      # The runner pool is pinned in those same scripts, not on this line, so a
-      # contributor's `pnpm test:unit` and this job share one isolation model.
-      # Why `threads`, and what enforces it: `src/runner-pool.test.ts`.
-      - run: pnpm -r run test:unit
-
-  templates:
-    # The bundled layer / overview templates are configuration that ships
-    # inside the release, so a broken one is a shipping defect, not operator
-    # error — and the loader only JSON.parses them, which is how an orderBy
-    # naming a nonexistent column and an unsupported aggregation both shipped.
-    # Its own status check rather than a line inside `lint`, so a template
-    # failure is legible from the check name. `pnpm lint` runs it too, so one
-    # local command still covers every gate.
-    name: Bundled templates
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm lint:templates
-
-  lint:
-    name: Lint + source budget
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      # ESLint (rules + 2000-line cap, comments excluded) across ui + bff,
-      # the source-budget gate (≤2000 code / ≤500 comment lines per file),
-      # both i18n gates: UI catalog coverage/parity (check-ui-i18n.mjs) and
-      # the BFF template-overlay validator (i18n:validate), then the bundled
-      # layer / overview templates themselves (templates:validate).
-      - run: pnpm lint
-
-  package:
-    # The two build jobs above compile the UI and the BFF separately; neither
-    # exercises `pnpm package`, which ASSEMBLES the distributable (the three
-    # packages/* builds, dist/server.js, the built UI at dist/static/, bundled
-    # templates, i18n catalogs, AI resources). Until this job existed that
-    # assembly ran for the first time inside the release image build — i.e.
-    # after merge — so a broken tarball merged green. Boot the artifact too:
-    # a dist/ that assembles but 404s at `/` is not a working release.
-    name: Package + boot artifact
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm package
+      # A dist/ that assembles but 404s at `/` is not a working release.
       - name: Boot the packaged server and smoke-test it
         run: |
           set -eu
@@ -263,20 +173,19 @@ jobs:
     # Status-check name pinned to "Required" so Apache branch protection
     # (`.asf.yaml: protected_branches.main.required_status_checks.contexts:
     # [Required]`) can gate on a single rolled-up signal.
+    #
+    # e2e-core is deliberately NOT rolled up yet. It reports on every PR and a
+    # red run is a real signal, but a suite this young blocking every merge
+    # trades one class of bug for a worse one — people learn to re-run it.
+    # Promote it by adding it to `needs` and asserting its result below, once
+    # it has held green across a few weeks of real PRs.
     if: always() && !cancelled()
     name: Required
-    needs: [license-header, dependency-license, type-check, build-ui, build-bff, test, lint, templates, package]
+    needs: [license-header, build-and-check]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check upstream jobs
         run: |
           [[ ${{ needs.license-header.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.dependency-license.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.type-check.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.build-ui.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.build-bff.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.test.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.lint.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.templates.result }} == 'success' ]] || exit 1
-          [[ ${{ needs.package.result }} == 'success' ]] || exit 1
+          [[ ${{ needs.build-and-check.result }} == 'success' ]] || exit 1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,156 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The gate `tsc` and unit tests cannot be: Horizon against a REAL OAP, fed by
+# real telemetry, verified on BOTH halves of the product — the BFF's HTTP
+# surface and the rendered UI in headless Chromium. A route that returns
+# correct JSON into a view that throws on mount passes every API assertion and
+# is blank for the operator; only the browser half catches that.
+#
+# Separate from ci.yaml because the two answer different questions and cost
+# different amounts. ci.yaml asks "does this compile, lint, package and boot?"
+# in ~3 minutes on one runner; this asks "does it actually work against a
+# backend?" and spends a stack of containers per case to find out.
+#
+# Every case is skywalking-infra-e2e driven — the same harness the rest of the
+# SkyWalking project uses. The case file owns setup / trigger / verify /
+# cleanup; Playwright is invoked from a verify case. Fixture, image pins and
+# local-run instructions: test/e2e/README.md.
+#
+#
+# ── CASE / FEATURE MATRIX ────────────────────────────────────────────────
+#
+# Cases are split by DEPLOYMENT, not by upstream fixture file. Upstream's log
+# case, for example, differs from simple/jdk by two OAP environment variables
+# and a LAL rule — the demo app, storage and topology are identical, so giving
+# it a stack of its own would spend a minute of container boot to learn
+# nothing. Anything the core stack can produce belongs in `core`.
+#
+# Adding a case is a directory under test/e2e/cases/ plus one `case:` entry in
+# the matrix below. Keep this table in step with both.
+#
+#   case        deployment difference        covers                             status
+#   ─────────────────────────────────────────────────────────────────────────────────
+#   core        —  (the baseline stack)      auth gate + session; OAP info,     ACTIVE
+#                                            menu caps; service roster and
+#                                            identity; traces (list + detail);
+#                                            metrics incl. JVM; LOGS via a LAL
+#                                            rule; TOPOLOGY nodes and edges;
+#                                            agent lifecycle EVENTS; and the
+#                                            rendered half of each — shell,
+#                                            picker, dashboard, traces, logs
+#                                            and topology tabs.
+#                                            templates.mode live is covered
+#                                            implicitly: the dashboard cannot
+#                                            render unless Horizon seeded the
+#                                            bundle into OAP and read it back.
+#
+#   dsl         —  (same stack, admin port)  DSL management + live debugger     PLANNED
+#                                            against OAP's admin host, which
+#                                            core already exposes. Folds in.
+#
+#   zipkin      Zipkin receiver              /api/zipkin/* and the              PLANNED
+#                                            zipkin-trace tab
+#   browser     client-js app                Browser Errors tab, source-map     PLANNED
+#                                            de-minification
+#   es          ElasticSearch storage        trace v1 (the ONLY path that       PLANNED
+#                                            reaches it — v2 is BanyanDB-only)
+#                                            and ES-only fuzzy log query
+#   deployment  BanyanDB CLUSTER             the Deployment component, which    PLANNED
+#                                            visualises BanyanDB self-
+#                                            observability. Needs liaison +
+#                                            data nodes, so it cannot ride on
+#                                            the standalone core stack.
+#
+#   profiling   varies per profiling type    trace / async / pprof tabs.        DEFERRED
+#                                            Each relies on a different
+#                                            deployment; revisit as a group.
+#   infra       kind + rover                 eBPF and network profiling,        DEFERRED
+#                                            K8S_SERVICE topology. Uses
+#                                            infra-e2e's `kind` environment,
+#                                            not compose, and cannot run on
+#                                            macOS — eBPF needs a Linux kernel.
+#
+# NOTE: instance topology is NOT a reason for a dedicated case — the core
+# fixture already produces it (consumer -> provider at instance level). Only
+# the Deployment component needs the BanyanDB cluster.
+
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: ${{ matrix.case.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      # One case failing must not cancel the others: when several go red at
+      # once, which ones they are is the diagnosis.
+      fail-fast: false
+      matrix:
+        case:
+          - name: core (BanyanDB)
+            config: test/e2e/cases/core/e2e.yaml
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      # Horizon and the instrumented demo services. Built here rather than
+      # pulled: the point is to test THIS commit, and compose sets
+      # pull_policy: never so a missing build fails loudly instead of silently
+      # testing someone else's image.
+      - name: Build the fixture images
+        run: make -C test/e2e images
+
+      - name: ${{ matrix.case.name }}
+        uses: apache/skywalking-infra-e2e@68bbdec303cf2d3df9f2353f970f91938b52f674
+        with:
+          e2e-file: $GITHUB_WORKSPACE/${{ matrix.case.config }}
+          # Container logs land here. On a red run they answer the first
+          # question — did the fixture break, or did Horizon? — which the
+          # Playwright report alone cannot.
+          log-dir: $GITHUB_WORKSPACE/e2e-logs
+
+      # Traces and screenshots are the only way to diagnose a UI failure that
+      # did not reproduce locally. Also on cancellation: a hung case hits the
+      # job timeout as `cancelled`, which a plain `failure()` would skip.
+      - name: Collect the Playwright report
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report-${{ strategy.job-index }}
+          path: |
+            test/e2e/playwright/playwright-report
+            test/e2e/playwright/test-results
+            e2e-logs
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,14 @@ coverage
 *.lcov
 .nyc_output
 
+# E2E run output: the Playwright report, traces/screenshots, and the session
+# state auth.setup.ts writes for the other projects.
+# Anywhere under test/e2e: Playwright resolves these against its cwd, which
+# differs between a case run and a direct invocation.
+test/e2e/**/playwright-report
+test/e2e/**/test-results
+test/e2e/**/.auth
+
 # Build artifacts
 *.tsbuildinfo
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,18 @@ importers:
         specifier: ~5.6.3
         version: 5.6.3
 
+  test/e2e/playwright:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.1
+        version: 1.62.1
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      typescript:
+        specifier: ~5.6.3
+        version: 5.6.3
+
 packages:
 
   '@asamuzakjp/css-color@3.2.0':
@@ -1207,6 +1219,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pmndrs/pointer-events@6.6.30':
     resolution: {integrity: sha512-YD2jWdgEqqAWJNOOZ1WZMunUby8jwuQyOMk8zbeqC39R4nkZnGvu1Pa5EMGbV1zd2vZTxXDxYcAVxtQuhVwf3g==}
@@ -2579,6 +2596,11 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3316,6 +3338,16 @@ packages:
 
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -5067,6 +5099,10 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pmndrs/pointer-events@6.6.30': {}
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -6687,6 +6723,9 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7402,6 +7441,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.2.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Local entry points. CI drives the same scripts, so a case can never be run
+# one way here and another way there.
+#
+#     make images          build the images compose expects (never pulled)
+#     make run CASE=core   full infra-e2e cycle for one case
+#     make setup CASE=core bring the stack up and leave it up
+#     make cleanup CASE=core
+
+E2E ?= e2e
+CASE ?= core
+CASE_FILE = cases/$(CASE)/e2e.yaml
+
+.PHONY: images
+images:
+	bash script/prepare/build-images.sh
+
+# Skips the slow Horizon build. Use while iterating on specs or compose, when
+# the app image is already current.
+.PHONY: images-demo
+images-demo:
+	SKIP_HORIZON_IMAGE=true bash script/prepare/build-images.sh
+
+.PHONY: run
+run:
+	$(E2E) run -c $(CASE_FILE)
+
+# Spec iteration: a stack that OUTLIVES the command that started it.
+#
+# `e2e setup` cannot do this. The cases set `cleanup: on: always`, which leaves
+# testcontainers' reaper enabled, so every container dies the moment the CLI
+# process exits — you get a stack for about a second. Driving compose directly
+# is the supported way to hold one open.
+#
+#     make dev                                    # start, stay up
+#     make dev-url                                # → the Horizon URL
+#     cd playwright && HORIZON_BASE_URL=<url> pnpm exec playwright test --project=ui --headed
+#     make dev-down
+.PHONY: dev dev-url dev-logs dev-down
+DEV := bash script/prepare/dev-compose.sh $(CASE)
+
+dev:
+	$(DEV) up -d --wait
+
+# compose reports the bind address (0.0.0.0), which is not a usable client
+# address — rewrite it to loopback so the output can be pasted straight in.
+dev-url:
+	@echo "http://$$($(DEV) port horizon 8081 | sed 's/^0\.0\.0\.0/127.0.0.1/')"
+
+# The stack alone produces NO data: in a case run it is infra-e2e's `trigger`
+# block that drives the demo app, and `make dev` has no equivalent. Without
+# this the roster is empty and most specs fail against a perfectly good build.
+.PHONY: dev-traffic
+dev-traffic:
+	@url=http://$$($(DEV) port consumer 9092 | sed 's/^0\.0\.0\.0/127.0.0.1/'); \
+	  secs=$${SECONDS_TO_RUN:-120}; \
+	  echo "driving $$url/users for $${secs}s"; \
+	  end=$$(( $$(date +%s) + secs )); \
+	  while [ $$(date +%s) -lt $$end ]; do \
+	    curl -sf -o /dev/null -X POST "$$url/users" \
+	      -H 'Content-Type: application/json' -d '{"id":"123","name":"skywalking"}' || true; \
+	    sleep 2; \
+	  done; \
+	  echo "traffic done"
+
+dev-logs:
+	$(DEV) logs
+
+dev-down:
+	$(DEV) down -v --remove-orphans

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,116 @@
+# End-to-end tests
+
+Runs Horizon against a **real OAP** on **BanyanDB**, fed by an instrumented demo app, and verifies both halves of the product: the BFF's HTTP surface and the rendered UI in a headless browser.
+
+This is the gate that unit tests and `tsc` cannot be. A green type-check proves the code compiles; it does not prove a widget resolves its MQE against live data, that the trace list renders what the BFF returned, or that a view mounts at all.
+
+Driven by [skywalking-infra-e2e](https://github.com/apache/skywalking-infra-e2e) — the same harness every other e2e in the SkyWalking project uses.
+
+## Layout
+
+```
+test/e2e/
+  script/
+    env                          image pins, loaded by every case
+    docker-compose/
+      base-compose.yml           service definitions shared by all cases
+    Dockerfile.demo-service      agent image + upstream service jar
+    prepare/                     installers and helpers used by cases
+  cases/
+    core/
+      e2e.yaml                   setup / trigger / verify / cleanup
+      docker-compose.yml         extends the base; adds ports + depends_on
+      expected/                  expected output per verify case
+  playwright/                    the Playwright project: config + specs
+```
+
+A case never redefines a service — it `extends` the one it needs from `base-compose.yml` and adds only what is case-specific. `extends` deliberately does not carry `depends_on`, so each case declares its own ordering; that is upstream's convention too.
+
+The Playwright project is **shared by all cases**, not per-case. A case reaches it through one verify line, so a new case reuses the same login, fixtures and config rather than standing up a second browser suite.
+
+## What the core case stands up
+
+| Service | Image | Notes |
+| --- | --- | --- |
+| `banyandb` | `ghcr.io/apache/skywalking-banyandb` | Storage. OAP's default selector, so no override needed. |
+| `oap` | `ghcr.io/apache/skywalking/oap` | Query on 12800, admin host (`ui-management`) on 17128. |
+| `provider` / `consumer` | SkyWalking Java agent + upstream e2e service jar | The demo app. Reports as `e2e-service-provider` / `e2e-service-consumer` in the `GENERAL` layer. |
+| `horizon` | built from this checkout | `templates.mode: live`, local auth, one admin account. |
+
+Every upstream image is **pinned by commit SHA in [`script/env`](script/env)**, the same shape as `apache/skywalking`'s `test/e2e-v2/script/env`. Nothing is built from an upstream checkout, so this directory plus that file is the entire dependency on the SkyWalking repo.
+
+## Run it locally
+
+Everything here works on macOS — all pinned images publish `linux/arm64` as well as `linux/amd64`, so nothing is emulated.
+
+You need the `e2e` CLI on `PATH`:
+
+```bash
+go install github.com/apache/skywalking-infra-e2e/cmd/e2e@latest
+```
+
+Then:
+
+```bash
+make -C test/e2e images            # build horizon-ui:e2e + the demo services
+make -C test/e2e run CASE=core     # full cycle: setup, trigger, verify, cleanup
+```
+
+`make images` is the slow one and only needs re-running when app code changes. While iterating on compose or specs, `make images-demo` skips the Horizon build.
+
+### Iterating on specs
+
+`make run` tears the stack down at the end, and `e2e setup` on its own is no help: the cases set `cleanup: on: always`, which leaves testcontainers' reaper enabled, so every container dies the moment the CLI process exits. Use the `dev` targets, which drive compose directly and hold the stack open:
+
+```bash
+make -C test/e2e dev                     # start, stay up
+make -C test/e2e dev-traffic             # drive the demo app (~2 min)
+make -C test/e2e dev-url                 # → http://127.0.0.1:<port>
+
+cd test/e2e/playwright
+HORIZON_BASE_URL=<url> pnpm exec playwright test --project=ui --headed
+open playwright-report/index.html
+
+make -C test/e2e dev-logs                # when something looks wrong
+make -C test/e2e dev-down
+```
+
+**`dev-traffic` is not optional.** The stack on its own produces no telemetry — in a case run it is infra-e2e's `trigger` block that drives the demo app, and the `dev` targets have no equivalent. Skip it and the service roster is empty, so most specs fail against a perfectly good build. Re-run it whenever the data has aged out of the window you are looking at.
+
+The `dev` stack uses its own compose project name, so it never collides with a case run.
+
+Host ports are ephemeral, not fixed: infra-e2e maps them and exports `${horizon_host}` / `${horizon_8081}` to the verify cases. That is what lets two cases run back to back without colliding, and it is why `HORIZON_BASE_URL` has no default — a default would let the suite run green against a stale stack from a previous case.
+
+### Not runnable locally
+
+Cases needing **rover / eBPF** cannot run on macOS: eBPF needs a Linux kernel, and those cases use infra-e2e's `kind` environment rather than compose. Nothing in the core fixture uses them.
+
+## Adding a case
+
+1. `mkdir test/e2e/cases/<name>` with a `docker-compose.yml` that `extends` the base and an `e2e.yaml`.
+2. Add expected files under `cases/<name>/expected/`.
+3. Add one entry to the `case:` matrix in `.github/workflows/e2e.yaml`, and a row to the case/feature matrix in its header comment.
+
+If the case needs UI coverage, add specs under `playwright/specs/` and a Playwright project, then call `script/prepare/playwright.sh <project> <url>` from a verify case.
+
+## Writing a spec that will not flake
+
+- **Assert on lists, not on chart points.** The fixture is minutes old. A widget on a 30-minute window over a two-minute-old OAP is legitimately empty; asserting "the chart has points" makes the suite fail for a correct UI.
+- **Scope UI locators to the element you mean.** Chart tooltips repeat endpoint names inside SVG `<title>` nodes, which match a text query but are never visible — a bare `getByText` can pass on a page whose list came back empty. Read the rendered DOM rather than inferring a selector from the component tree; the widgets do not always use the primitive you would expect.
+- **Cascade-clear is a real state.** The UI resets a dependent area and shows a reading hint before its query lands. Wait for the resolved state, never assert on the frame between the click and the result.
+- **No retries.** `retries: 0` is deliberate — a rerun hides exactly the class of flake this suite exists to find. An intermittent failure means the wait is wrong. Slow-to-settle data belongs in the case's `verify.retry` budget instead, where it is declared once.
+- **OAP data is never translated.** Service and endpoint names come over the wire verbatim, so they are safe to assert on literally. UI chrome is i18n-resolved — match structure or classes, not English strings.
+
+## Bumping the pins
+
+Pick a commit from the relevant upstream master, confirm the image tag exists, then edit [`script/env`](script/env):
+
+```bash
+docker manifest inspect ghcr.io/apache/skywalking/oap:<sha>
+```
+
+The OAP pin must stay at or after `5b481a41a9` (#13877) — the commit that added the `ui-management` module Horizon's template store talks to. Below it, `templates.mode: live` cannot work at all.
+
+Never replace a pin with `latest`: an unrelated push to an upstream master would then turn this repo's CI red with no commit of ours involved, and it would read as our regression.
+
+**Nothing in `script/env` may be quoted.** infra-e2e reads it by splitting each line on the first `=` and exporting the remainder verbatim — no quote stripping, no expansion. A quoted value ships its quote characters into the container. For the same reason no script may shell-source the file; read individual keys instead, as `script/prepare/build-images.sh` does.

--- a/test/e2e/cases/core/docker-compose.yml
+++ b/test/e2e/cases/core/docker-compose.yml
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Core case: the whole stack on BanyanDB, with the Java demo app producing
+# GENERAL-layer services, endpoints, traces and metrics.
+#
+# Every service comes from the shared base; this file adds only the ordering
+# and the ports the verify cases need to reach. `extends` does not carry
+# depends_on, which is why the chain is declared here rather than centrally.
+
+services:
+  banyandb:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: banyandb
+    ports:
+      - 17912
+
+  oap:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: oap
+    ports:
+      - 12800
+      - 17128
+    depends_on:
+      banyandb:
+        condition: service_healthy
+
+  provider:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: provider
+    ports:
+      - 9090
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  consumer:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: consumer
+    ports:
+      # Published so the `trigger` block can drive the demo app from the host.
+      - 9092
+    depends_on:
+      provider:
+        condition: service_healthy
+
+  horizon:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: horizon
+    ports:
+      - 8081
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/core/e2e.yaml
+++ b/test/e2e/cases/core/e2e.yaml
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Core case — Horizon against a live OAP on BanyanDB, verified on BOTH halves:
+# the BFF's HTTP surface and the rendered UI in headless Chromium.
+#
+# Run it:  e2e run -c test/e2e/cases/core/e2e.yaml
+# Images:  make -C test/e2e images   (must exist first; compose never pulls them)
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 30m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e/script/prepare/install.sh yq
+    - name: install swctl
+      command: bash test/e2e/script/prepare/install.sh swctl
+    # No browser install: the suite runs inside the pinned Ubuntu image, so
+    # the host needs nothing beyond docker. This only clears stale fail-fast
+    # markers and pre-pulls the image.
+    - name: prepare browser image
+      command: bash test/e2e/script/prepare/install.sh playwright
+    # Logs come from a different endpoint than the one `trigger` drives — see
+    # the script. Seeded here so the log assertions have something to find.
+    - name: seed log traffic
+      command: bash test/e2e/script/prepare/log-traffic.sh http://${provider_host}:${provider_9090}
+
+trigger:
+  # Keeps running through verification, so the metrics windows the dashboard
+  # widgets query stay populated rather than ageing out mid-suite.
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${consumer_host}:${consumer_9092}/users
+  method: POST
+  body: '{"id":"123","name":"skywalking"}'
+  headers:
+    "Content-Type": "application/json"
+
+verify:
+  # The roster behind every UI assertion is served from a catalog cached with
+  # a 60s TTL, so a correct Horizon answers with an empty roster for up to a
+  # minute after the agents register. This retry budget is that window; it is
+  # why the specs themselves need no long polls.
+  retry:
+    count: 40
+    interval: 5s
+  cases:
+    # 1. Fixture sanity FIRST, straight off OAP. If this fails the demo app or
+    #    the agent is broken, and no amount of reading Horizon will show it —
+    #    the distinction that costs the most time when a UI suite goes red.
+    - query: |
+        swctl --display json --base-url=http://${oap_host}:${oap_12800}/graphql service ls \
+          | yq -P '{"demoServices": [.[] | select(.name == "e2e-service-provider" or .name == "e2e-service-consumer")] | length}'
+      expected: expected/demo-services.yml
+
+    # 2. Horizon serves that same roster. Bridges "OAP has it" to "Horizon can
+    #    see it", and absorbs the catalog TTL via the retry budget above.
+    - query: |
+        bash test/e2e/script/prepare/horizon-get.sh \
+          "http://${horizon_host}:${horizon_8081}" /api/layer/general/services \
+          | yq -P '{"reachable": .reachable, "demoServices": [.services[] | select(.name == "e2e-service-provider" or .name == "e2e-service-consumer")] | length}'
+      expected: expected/horizon-roster.yml
+
+    # 3. Metrics have actually landed — the gate the browser cases depend on.
+    #    Services register within seconds, but OAP persists metrics on a ~25s
+    #    cycle and aggregates into minute buckets, so for a while after the
+    #    roster is populated every metric widget is still legitimately empty.
+    #    Without this gate that wait falls to the `ui` case, which absorbs it
+    #    by RETRYING — re-running the whole browser project each time, and
+    #    turning a timing question into what looks like a flaky UI.
+    #    service_cpm is what the layer dashboard's traffic widgets read.
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql \
+          metrics exec --expression=service_cpm --service-name=e2e-service-provider
+      expected: expected/metrics-has-value.yml
+
+    # 4. The consumer -> provider EDGE exists, not merely both services.
+    #    service_cpm above is satisfied by the log burst alone, which hits the
+    #    provider directly — so the metrics gate can open while the topology
+    #    still has no relation in it. Relation metrics aggregate on their own
+    #    cycle from the trigger traffic, and the topology assertions need that
+    #    to have landed. Missing this is what turned CI red while the same
+    #    suite passed locally, where the consumer had been driven first.
+    - query: |
+        bash test/e2e/script/prepare/horizon-get.sh \
+          "http://${horizon_host}:${horizon_8081}" "/api/layer/general/topology?windowMinutes=30" \
+          | yq -P '{"demoNodes": [.nodes[] | select(.name == "e2e-service-provider" or .name == "e2e-service-consumer")] | length, "hasCalls": (.calls | length > 0)}'
+      expected: expected/has-topology.yml
+
+    # 5. Logs reached OAP and survived the LAL pipeline. Separate from the
+    #    metrics gate because a log can fail for its own reasons — a missing
+    #    LAL rule drops every record while traces and metrics stay perfect.
+    - query: |
+        swctl --display json --base-url=http://${oap_host}:${oap_12800}/graphql \
+          logs list --service-name=e2e-service-provider \
+          | yq -P '{"hasLogs": (.logs | length > 0)}'
+      expected: expected/has-logs.yml
+
+    # 6+7. The suites. Playwright owns its own assertions and reporting; the
+    #      contract with infra-e2e is only "exit 0 and print passed: true".
+    #      Split by project so a red run says which half broke — a route
+    #      returning correct JSON into a view that throws on mount passes
+    #      every API assertion and is blank for the operator.
+    - query: |
+        bash test/e2e/script/prepare/playwright.sh bff
+      expected: expected/passed.yml
+
+    - query: |
+        bash test/e2e/script/prepare/playwright.sh ui
+      expected: expected/passed.yml
+
+
+cleanup:
+  on: always

--- a/test/e2e/cases/core/expected/demo-services.yml
+++ b/test/e2e/cases/core/expected/demo-services.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+demoServices: 2

--- a/test/e2e/cases/core/expected/has-logs.yml
+++ b/test/e2e/cases/core/expected/has-logs.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+hasLogs: true

--- a/test/e2e/cases/core/expected/has-topology.yml
+++ b/test/e2e/cases/core/expected/has-topology.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+demoNodes: 2
+hasCalls: true

--- a/test/e2e/cases/core/expected/horizon-roster.yml
+++ b/test/e2e/cases/core/expected/horizon-roster.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+reachable: true
+demoServices: 2

--- a/test/e2e/cases/core/expected/metrics-has-value.yml
+++ b/test/e2e/cases/core/expected/metrics-has-value.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Asserts only that PERSISTED data exists: at least one bucket carries a value.
+#
+# Deliberately does NOT pin the newest bucket. OAP persists on a ~25s cycle and
+# aggregates into minute buckets, so whether the last bucket is null or filled
+# depends purely on when the query lands relative to that cycle — upstream's
+# copy of this file asserts a trailing null, which is a coin flip rather than a
+# contract. `contains` means "the actual data includes at least this", so one
+# filled bucket is the whole assertion.
+debuggingtrace: null
+type: TIME_SERIES_VALUES
+results:
+  {{- contains .results }}
+  - metric:
+      labels: []
+    values:
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ notEmpty .value }}
+        owner: null
+        traceid: null
+      {{- end}}
+  {{- end}}
+error: null

--- a/test/e2e/cases/core/expected/passed.yml
+++ b/test/e2e/cases/core/expected/passed.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+passed: true

--- a/test/e2e/playwright/package.json
+++ b/test/e2e/playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@skywalking-horizon-ui/e2e-playwright",
+  "version": "1.0.0-dev",
+  "private": true,
+  "type": "module",
+  "description": "Playwright suite invoked by the infra-e2e cases: BFF API assertions plus headless-browser UI journeys",
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1",
+    "@types/node": "^22.20.1",
+    "typescript": "~5.6.3"
+  }
+}

--- a/test/e2e/playwright/playwright.config.ts
+++ b/test/e2e/playwright/playwright.config.ts
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, devices } from '@playwright/test';
+
+// infra-e2e maps container ports to ephemeral host ports and exports them to
+// the verify case, which passes the resolved URL in. There is no default:
+// guessing one would let the suite run green against a stale stack from a
+// previous case, which is worse than failing to start.
+const baseURL = process.env.HORIZON_BASE_URL;
+if (!baseURL) {
+  throw new Error(
+    'HORIZON_BASE_URL is not set. Run through an infra-e2e case ' +
+      '(`e2e run -c test/e2e/cases/core/e2e.yaml`), or export it by hand when ' +
+      'iterating against a stack you started yourself.',
+  );
+}
+
+// Anchored to this file, not to the cwd: the verify case invokes Playwright
+// through `pnpm --dir`, which resolves the package but leaves the process cwd
+// wherever infra-e2e started it, so a relative path lands outside the package.
+const here = dirname(fileURLToPath(import.meta.url));
+
+export const AUTH_STATE = resolve(here, '.auth/state.json');
+
+export default defineConfig({
+  testDir: './specs',
+  // The fixture is a shared, stateful stack — parallel workers would race on
+  // the same OAP and on template writes. Serial also makes a failure
+  // reproducible from the log order.
+  workers: 1,
+  fullyParallel: false,
+  // A retry masks exactly the flake class this suite exists to catch, so the
+  // answer to an intermittent failure is a better wait, not a rerun.
+  retries: 0,
+  // Output goes to stderr (see script/prepare/playwright.sh) — stdout is the
+  // infra-e2e contract. The HTML report is for the CI failure artifact.
+  reporter: [
+    ['line'],
+    ['html', { open: 'never', outputFolder: resolve(here, 'playwright-report') }],
+  ],
+  // Same anchoring as AUTH_STATE — the CI failure artifact collects these two
+  // paths by name, so they must not follow the caller's cwd.
+  outputDir: resolve(here, 'test-results'),
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'auth', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'bff',
+      testMatch: /bff\/.*\.spec\.ts/,
+      dependencies: ['auth'],
+      use: { storageState: AUTH_STATE },
+    },
+    {
+      name: 'ui',
+      testMatch: /ui\/.*\.spec\.ts/,
+      dependencies: ['auth'],
+      use: { ...devices['Desktop Chrome'], storageState: AUTH_STATE },
+    },
+  ],
+});

--- a/test/e2e/playwright/specs/auth.setup.ts
+++ b/test/e2e/playwright/specs/auth.setup.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { AUTH_STATE } from '../playwright.config.js';
+import { E2E_USER, E2E_PASSWORD } from './fixture.js';
+
+// Signs in once through the real login form and hands the session cookie to
+// every other project. Driving the form rather than POSTing /api/auth/login
+// means a broken login page fails here, loudly, instead of leaving every UI
+// spec to fail on a redirect nobody expected.
+test('sign in', async ({ page }) => {
+  await page.goto('/');
+
+  await page.fill('input[name="username"]', E2E_USER);
+  await page.fill('input[name="password"]', E2E_PASSWORD);
+  await page.click('button.sign-in');
+
+  await expect(page).not.toHaveURL(/\/login\b/);
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
+
+  await page.context().storageState({ path: AUTH_STATE });
+});

--- a/test/e2e/playwright/specs/bff/auth.spec.ts
+++ b/test/e2e/playwright/specs/bff/auth.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, request } from '@playwright/test';
+import { E2E_USER, E2E_PASSWORD } from '../fixture.js';
+
+test('health is reachable without a session', async ({ request: api }) => {
+  expect((await api.get('/api/health')).status()).toBe(200);
+});
+
+test('query routes reject an unauthenticated caller', async ({ baseURL }) => {
+  // storageState must be cleared EXPLICITLY: request.newContext() inherits it
+  // from the project's `use`, so a bare newContext() is still signed in and
+  // this test would pass against a Horizon with no auth at all.
+  const anon = await request.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
+  for (const path of ['/api/menu', '/api/oap/info', '/api/layer/general/services']) {
+    expect((await anon.get(path)).status(), `${path} must require auth`).toBe(401);
+  }
+  await anon.dispose();
+});
+
+test('sign-in issues an http-only session cookie', async ({ baseURL }) => {
+  const anon = await request.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
+  const res = await anon.post('/api/auth/login', {
+    data: { username: E2E_USER, password: E2E_PASSWORD },
+  });
+  expect(res.status()).toBe(200);
+
+  const cookie = (await anon.storageState()).cookies.find((c) => c.name === 'horizon_sid');
+  expect(cookie, 'login must set horizon_sid').toBeDefined();
+  expect(cookie?.httpOnly, 'session cookie must be http-only').toBe(true);
+  await anon.dispose();
+});
+
+test('bad credentials are refused', async ({ baseURL }) => {
+  const anon = await request.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
+  const res = await anon.post('/api/auth/login', {
+    data: { username: E2E_USER, password: 'not-the-password' },
+  });
+  expect(res.status()).toBeGreaterThanOrEqual(400);
+  await anon.dispose();
+});
+
+test('the session identifies the fixture account and its role', async ({ request: api }) => {
+  const me = await (await api.get('/api/auth/me')).json();
+  expect(me.username).toBe(E2E_USER);
+  expect(me.roles).toContain('admin');
+});

--- a/test/e2e/playwright/specs/bff/query.spec.ts
+++ b/test/e2e/playwright/specs/bff/query.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  PROVIDER_SERVICE,
+  CONSUMER_SERVICE,
+  DEMO_ENDPOINTS,
+  LAYER,
+  WINDOW_MINUTES,
+} from '../fixture.js';
+
+test('OAP is reachable and reports the storage the fixture runs on', async ({ request: api }) => {
+  const info = await (await api.get('/api/oap/info')).json();
+  expect(info.reachable).toBe(true);
+  expect(info.backend).toBe('banyandb');
+  expect(info.version, 'version must come from the live OAP').toBeTruthy();
+  // The BFF converts every query window into OAP-server-local time off this
+  // field. A missing offset silently shifts every query by the host's zone.
+  expect(info.timezone).toMatch(/^[+-]\d{4}$/);
+});
+
+test('the menu exposes the layer the demo app reports into', async ({ request: api }) => {
+  const menu = await (await api.get('/api/menu')).json();
+  const general = menu.layers.find((l: { key: string }) => l.key === LAYER);
+  expect(general, `menu must carry the ${LAYER} layer`).toBeDefined();
+  // Capabilities drive which tabs the layer shell renders; traces being
+  // false here would blank the traces tab with no error anywhere.
+  expect(general.caps.traces).toBe(true);
+});
+
+test('the service roster carries both demo services', async ({ request: api }) => {
+  const res = await api.get(`/api/layer/${LAYER}/services`);
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  expect(body.reachable).toBe(true);
+  expect(body.layer).toBe(LAYER.toUpperCase());
+
+  const names = body.services.map((s: { name: string }) => s.name);
+  expect(names).toContain(PROVIDER_SERVICE);
+  expect(names).toContain(CONSUMER_SERVICE);
+
+  // Identity is carried as an {id, name} pair; an empty id means downstream
+  // per-service queries silently address nothing.
+  for (const svc of body.services) {
+    expect(svc.id, `${svc.name} must carry an OAP id`).toBeTruthy();
+  }
+});
+
+test('an unknown layer key is rejected, not answered with an empty roster', async ({
+  request: api,
+}) => {
+  const res = await api.get('/api/layer/not@a@layer/services');
+  expect(res.status()).toBe(400);
+});
+
+test('traces from the demo app come back with spans', async ({ request: api }) => {
+  const res = await api.post(`/api/layer/${LAYER}/traces`, {
+    data: { windowMinutes: WINDOW_MINUTES, pageSize: 10 },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  const traces = body.native?.traces ?? [];
+  expect(traces.length, 'the demo traffic must produce traces').toBeGreaterThan(0);
+
+  const first = traces[0];
+  expect(first.traceIds?.length).toBeGreaterThan(0);
+  expect(first.endpointNames?.length).toBeGreaterThan(0);
+
+  // Every trace must belong to the demo app. Asserting provenance rather than
+  // one specific endpoint on purpose: the fixture drives BOTH /users
+  // (continuously, for topology) and /logs/trigger (a burst, for logs), so
+  // which endpoint owns the newest page depends on traffic mix — an
+  // `includes('/users')` here passes or fails on timing, not on correctness.
+  const endpoints = traces.flatMap((t: { endpointNames: string[] }) => t.endpointNames);
+  expect(endpoints.length).toBeGreaterThan(0);
+  expect(
+    endpoints.every((e: string) => DEMO_ENDPOINTS.some((known) => e.includes(known))),
+    `unexpected endpoints in the trace list: ${endpoints.join(', ')}`,
+  ).toBe(true);
+});
+
+test('a trace can be fetched by id and spans name the demo services', async ({ request: api }) => {
+  const list = await (
+    await api.post(`/api/layer/${LAYER}/traces`, {
+      data: { windowMinutes: WINDOW_MINUTES, pageSize: 1 },
+    })
+  ).json();
+  const traceId = list.native.traces[0].traceIds[0];
+
+  const detail = await api.get(`/api/trace/${encodeURIComponent(traceId)}`);
+  expect(detail.status()).toBe(200);
+
+  // Spans hang off the per-source envelope, not the root — the response
+  // carries `native` and `zipkin` side by side.
+  const spans = (await detail.json()).native?.spans ?? [];
+  expect(spans.length).toBeGreaterThan(0);
+  // Same reason as the endpoint set above: a /logs/trigger trace is
+  // provider-only, so requiring the consumer here would fail whenever the
+  // newest trace came from the log burst rather than the topology call.
+  const services = spans.map((s: { serviceCode: string }) => s.serviceCode);
+  expect(
+    services.every((s: string) => s === PROVIDER_SERVICE || s === CONSUMER_SERVICE),
+    `unexpected services in the trace: ${services.join(', ')}`,
+  ).toBe(true);
+});

--- a/test/e2e/playwright/specs/bff/signals.spec.ts
+++ b/test/e2e/playwright/specs/bff/signals.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { PROVIDER_SERVICE, CONSUMER_SERVICE, LAYER, WINDOW_MINUTES } from '../fixture.js';
+
+// The signals beyond trace + metric that the same fixture already produces:
+// topology, logs and events. They live together because they share the demo
+// app — none of them needs a stack of its own.
+
+/** OAP identity is an {id, name} PAIR; routes reject a name on its own. */
+async function serviceIdentity(api: APIRequestContext, name: string) {
+  const roster = await (await api.get(`/api/layer/${LAYER}/services`)).json();
+  const svc = roster.services.find((s: { name: string }) => s.name === name);
+  expect(svc, `${name} must be in the roster`).toBeDefined();
+  return { serviceId: svc.id as string, service: svc.name as string };
+}
+
+test('the topology graph carries the demo call chain', async ({ request: api }) => {
+  const res = await api.get(`/api/layer/${LAYER}/topology?windowMinutes=${WINDOW_MINUTES}`);
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  expect(body.reachable).toBe(true);
+  const names = body.nodes.map((n: { name: string }) => n.name);
+  expect(names).toContain(PROVIDER_SERVICE);
+  expect(names).toContain(CONSUMER_SERVICE);
+
+  // The edge is the point: nodes alone would appear even if the two services
+  // never talked to each other, which is precisely the bug a topology screen
+  // exists to show.
+  expect(body.calls.length, 'the consumer -> provider call must be an edge').toBeGreaterThan(0);
+});
+
+test('logs from the demo app are queryable for a service', async ({ request: api }) => {
+  const identity = await serviceIdentity(api, PROVIDER_SERVICE);
+
+  const res = await api.post(`/api/layer/${LAYER}/logs`, {
+    data: { ...identity, windowMinutes: WINDOW_MINUTES, pageSize: 10 },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  expect(body.reachable, body.error ?? 'log query must reach OAP').toBe(true);
+  // A LAL rule that drops everything leaves this empty while traces and
+  // metrics stay perfect — the failure this assertion exists for.
+  expect(body.logs.length, 'the demo app must have produced logs').toBeGreaterThan(0);
+  expect(body.logs[0].serviceName).toBe(PROVIDER_SERVICE);
+  expect(body.logs[0].content, 'a log line must carry its content').toBeTruthy();
+});
+
+test('a log query without the service id is refused, not silently empty', async ({
+  request: api,
+}) => {
+  // Identity is an {id, name} pair. Answering a half-identity with an empty
+  // list would read as "no logs" and send an operator hunting the wrong bug.
+  const res = await api.post(`/api/layer/${LAYER}/logs`, {
+    data: { service: PROVIDER_SERVICE, windowMinutes: WINDOW_MINUTES, pageSize: 5 },
+  });
+  const body = await res.json();
+  expect(body.reachable).toBe(false);
+  expect(body.error).toContain('serviceId');
+});
+
+test('the agent reports lifecycle events', async ({ request: api }) => {
+  const res = await api.post('/api/events', {
+    data: { windowMinutes: 60, pageSize: 20 },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  expect(body.events.length, 'the Java agent must report a Start event').toBeGreaterThan(0);
+  const services = body.events.map((e: { source: { service: string } }) => e.source.service);
+  expect(services.some((s: string) => s === PROVIDER_SERVICE || s === CONSUMER_SERVICE)).toBe(true);
+});

--- a/test/e2e/playwright/specs/fixture.ts
+++ b/test/e2e/playwright/specs/fixture.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Facts about the fixture that specs assert against. Kept in one place so a
+ * compose change (a renamed demo service, a different account) lands in a
+ * single file rather than across every spec.
+ *
+ * The credentials mirror `test/e2e/env` — the compose stack is the source of
+ * truth, these are the defaults it ships with.
+ */
+
+export const E2E_USER = process.env.HORIZON_E2E_USER ?? 'e2e';
+export const E2E_PASSWORD = process.env.HORIZON_E2E_PASSWORD ?? 'e2e-passw0rd';
+
+/** Service names the instrumented demo app reports to OAP. */
+export const PROVIDER_SERVICE = 'e2e-service-provider';
+export const CONSUMER_SERVICE = 'e2e-service-consumer';
+
+/**
+ * Endpoints the demo app serves. `/users` is the consumer -> provider call the
+ * `trigger` block drives continuously (it is what produces the topology);
+ * `/logs/trigger` is the log-emitting endpoint seeded once at setup.
+ *
+ * Assertions match against this SET rather than one member: which endpoint
+ * owns the newest page of traces depends on traffic mix, so pinning one makes
+ * a correct build fail on timing.
+ */
+export const DEMO_ENDPOINTS = ['/users', '/logs/trigger'];
+
+/**
+ * The layer the Java agent's services land in. Everything the core fixture
+ * produces is GENERAL — a case that needs MESH or K8S_SERVICE needs a
+ * different fixture, not a different assertion here.
+ */
+export const LAYER = 'general';
+
+/**
+ * Widest window the suite ever asks for. The fixture is minutes old, so a
+ * longer window buys nothing and a shorter one races the metrics boundary.
+ */
+export const WINDOW_MINUTES = 30;

--- a/test/e2e/playwright/specs/ui/layer.spec.ts
+++ b/test/e2e/playwright/specs/ui/layer.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { PROVIDER_SERVICE, CONSUMER_SERVICE, DEMO_ENDPOINTS, LAYER } from '../fixture.js';
+
+// These assert on OAP-supplied names (service and endpoint names), which are
+// rendered verbatim in every locale. UI chrome is i18n-resolved, so it is
+// matched structurally instead — an English string here would fail the moment
+// the fixture ran under another locale.
+
+/** The roster lives behind the header's service switch, not inline. */
+async function openPicker(page: Page) {
+  await page.locator('.service-row button.switch').click();
+  const picker = page.locator('.picker-table');
+  await expect(picker).toBeVisible();
+  return picker;
+}
+
+test('the layer header resolves a service from the live roster', async ({ page }) => {
+  await page.goto(`/layer/${LAYER}/service`);
+
+  // Auto-selected from OAP's roster; an empty or placeholder name here means
+  // the landing never resolved an entity and every widget below is querying
+  // nothing.
+  await expect(page.locator('.service-row .svc-name')).toHaveText(PROVIDER_SERVICE);
+});
+
+test('the service picker lists both demo services', async ({ page }) => {
+  await page.goto(`/layer/${LAYER}/service`);
+  const picker = await openPicker(page);
+
+  await expect(picker.getByText(PROVIDER_SERVICE, { exact: true })).toBeVisible();
+  await expect(picker.getByText(CONSUMER_SERVICE, { exact: true })).toBeVisible();
+});
+
+test('filtering the picker narrows the roster', async ({ page }) => {
+  await page.goto(`/layer/${LAYER}/service`);
+  const picker = await openPicker(page);
+  await expect(picker.getByText(CONSUMER_SERVICE, { exact: true })).toBeVisible();
+
+  await page.locator('input.search').fill('provider');
+
+  await expect(picker.getByText(PROVIDER_SERVICE, { exact: true })).toBeVisible();
+  await expect(picker.getByText(CONSUMER_SERVICE, { exact: true })).toHaveCount(0);
+});
+
+test('picking a service switches the header to it', async ({ page }) => {
+  await page.goto(`/layer/${LAYER}/service`);
+  await expect(page.locator('.service-row .svc-name')).toHaveText(PROVIDER_SERVICE);
+
+  const picker = await openPicker(page);
+  await picker.locator('tr.row', { hasText: CONSUMER_SERVICE }).click();
+
+  // Selection is the upstream control every widget on the tab keys on. If it
+  // does not stick, the page renders the previous service's data under the
+  // new name — the failure operators cannot see.
+  await expect(page.locator('.service-row .svc-name')).toHaveText(CONSUMER_SERVICE);
+});
+
+test('the service dashboard renders widgets driven by live metrics', async ({ page }) => {
+  const crashes: string[] = [];
+  page.on('pageerror', (e) => crashes.push(e.message));
+
+  await page.goto(`/layer/${LAYER}/service`);
+
+  // Scoped to the table widget's own cells, for the same reason the traces
+  // assertion is: an unscoped text query also matches the chart tooltips'
+  // SVG <title>, so it would pass on a dashboard whose Top-N table came back
+  // empty. The endpoint name is OAP data reaching a widget through a bundled
+  // template's MQE — the whole render path in one assertion.
+  const topN = page.locator('.top-list .rows .row span.name');
+  await expect(topN.first()).toBeVisible({ timeout: 45_000 });
+  // Any demo endpoint, not one specific one: the widget ranks by traffic and
+  // the fixture drives two endpoints, so pinning one turns a correct render
+  // into a failure whenever the mix shifts.
+  const listed = await topN.allTextContents();
+  expect(
+    listed.some((name) => DEMO_ENDPOINTS.some((known) => name.includes(known))),
+    `Top-N showed none of the demo endpoints: ${listed.join(', ')}`,
+  ).toBe(true);
+
+  expect(crashes, 'an uncaught error during mount blanks the page').toEqual([]);
+});
+
+test('the traces tab returns traces produced by the demo app', async ({ page }) => {
+  const crashes: string[] = [];
+  page.on('pageerror', (e) => crashes.push(e.message));
+
+  await page.goto(`/layer/${LAYER}/trace`);
+
+  // Traces do not auto-fire: the tab owns its own time range and waits for an
+  // explicit Run query, because a trace query is expensive enough that firing
+  // it on navigation would hammer OAP. Drive the real control.
+  const run = page.locator('button.tr-run-btn');
+  await expect(run).toBeEnabled();
+  await run.click();
+
+  // Assert on a LIST ROW, not on the text anywhere: the scatter chart carries
+  // the same endpoint name inside an SVG <title>, which matches a text query
+  // but is never visible. A bare getByText here passes on a page whose trace
+  // list is empty.
+  const rows = page.locator('.tr-rowlist .tr-row-card');
+  await expect(rows.first()).toBeVisible({ timeout: 45_000 });
+  // Which endpoint owns the newest trace depends on traffic mix — see
+  // DEMO_ENDPOINTS. Assert provenance, not a particular endpoint.
+  const endpoint = await rows.first().locator('.tr-ep').textContent();
+  expect(
+    DEMO_ENDPOINTS.some((known) => endpoint?.includes(known)),
+    `unexpected endpoint in the trace list: ${endpoint}`,
+  ).toBe(true);
+
+  expect(crashes).toEqual([]);
+});

--- a/test/e2e/playwright/specs/ui/layout.spec.ts
+++ b/test/e2e/playwright/specs/ui/layout.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, type Locator } from '@playwright/test';
+import { LAYER } from '../fixture.js';
+
+// Layout failures the content assertions are blind to: a collapsed widget
+// grid, a chart drawn zero pixels tall, a panel that overflows its container.
+// All of them satisfy toBeVisible(), which only asks for a non-empty box.
+//
+// Geometry, deliberately — NOT screenshot comparison. These pages are full of
+// live values, so a pixel baseline would differ every run and get re-based
+// until nobody read it. Measuring boxes says the same thing about layout and
+// says it identically on every platform. Screenshots stay what they should
+// be: evidence attached to a failure.
+
+test('the dashboard widget grid tiles rather than collapsing', async ({ page }) => {
+  await page.goto(`/layer/${LAYER}/service`);
+
+  // `.widget`, not `.sw-card`: the service picker is also a card, so a
+  // first-visible wait on the broader selector is satisfied before a single
+  // widget has rendered, and the count then reads 1.
+  const widgets = page.locator('.widget');
+  // Waiting on the 5th settles the grid — the count is read after the
+  // template has laid out, not mid-render.
+  await expect(widgets.nth(4)).toBeVisible({ timeout: 45_000 });
+
+  const count = await widgets.count();
+  const boxes: NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const box = await widgets.nth(i).boundingBox();
+    expect(box, `widget ${i} has no box`).not.toBeNull();
+    // A zero-height card is the classic symptom of a chart that failed to
+    // size itself; on screen it reads as "no data".
+    expect(box!.height, `widget ${i} collapsed to ${box!.height}px tall`).toBeGreaterThan(40);
+    expect(box!.width, `widget ${i} collapsed to ${box!.width}px wide`).toBeGreaterThan(80);
+    boxes.push(box!);
+  }
+
+  const topRow = boxes.filter((b) => Math.abs(b.y - boxes[0].y) < 8);
+  expect(topRow.length, 'widgets stacked vertically instead of tiling').toBeGreaterThan(1);
+});
+
+test('no page scrolls sideways', async ({ page }) => {
+  for (const path of [`/layer/${LAYER}/service`, `/layer/${LAYER}/topology`, '/']) {
+    await page.goto(path);
+    await page.waitForTimeout(2500);
+    // Horizontal overflow means something refuses to shrink — a table with a
+    // minimum width, or a chart sized in absolute pixels.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow, `${path} overflows horizontally by ${overflow}px`).toBeLessThanOrEqual(1);
+  }
+});

--- a/test/e2e/playwright/specs/ui/shell.spec.ts
+++ b/test/e2e/playwright/specs/ui/shell.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+// A blank page with a console error is the failure mode this file exists for:
+// a TDZ ReferenceError in a view's setup aborts the mount silently, leaving a
+// 200 response, valid JSON underneath, and nothing on screen.
+test('the app shell mounts without a page error', async ({ page }) => {
+  const crashes: string[] = [];
+  page.on('pageerror', (e) => crashes.push(e.message));
+
+  await page.goto('/');
+  await expect(page.locator('#app')).toBeVisible();
+  // Signed in: the login form must be gone, not merely navigated past.
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
+
+  expect(crashes, 'an uncaught error during mount blanks the page').toEqual([]);
+});
+
+test('an unauthenticated visitor is sent to the login form', async ({ browser }) => {
+  // Explicitly session-less — the project default would carry one in.
+  const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const page = await ctx.newPage();
+
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/login\b/);
+  await expect(page.locator('input[name="username"]')).toBeVisible();
+  await expect(page.locator('input[name="password"]')).toBeVisible();
+
+  await ctx.close();
+});
+
+test('wrong credentials keep the operator on the login form', async ({ browser }) => {
+  const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const page = await ctx.newPage();
+
+  await page.goto('/login');
+  await page.fill('input[name="username"]', 'nobody');
+  await page.fill('input[name="password"]', 'wrong');
+  await page.click('button.sign-in');
+
+  await expect(page.locator('.error')).toBeVisible();
+  await expect(page).toHaveURL(/\/login\b/);
+
+  await ctx.close();
+});
+
+test('a deep link resolves to a rendered route, not a 404', async ({ page, baseURL }) => {
+  // The SPA fallback serving index.html is a BFF concern; the route actually
+  // resolving to a component is a router concern. Both, in one hop.
+  const anon = await request.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
+  expect((await anon.get('/layer/general/trace')).status()).toBe(200);
+  await anon.dispose();
+
+  await page.goto('/layer/general/trace');
+  await expect(page.locator('#app')).toBeVisible();
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
+});

--- a/test/e2e/playwright/specs/ui/signals.spec.ts
+++ b/test/e2e/playwright/specs/ui/signals.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { LAYER } from '../fixture.js';
+
+// The rendered half of the signals asserted on the wire in bff/signals.spec.ts.
+// Both halves matter: the BFF returning a correct topology graph proves
+// nothing about whether the operator can see it.
+
+test('the topology tab draws the demo call graph', async ({ page }) => {
+  const crashes: string[] = [];
+  page.on('pageerror', (e) => crashes.push(e.message));
+
+  await page.goto(`/layer/${LAYER}/topology`);
+
+  // Nodes are real DOM elements carrying data-node-id, not painted into an
+  // HTML canvas, so they can be addressed directly.
+  const nodes = page.locator('.sm-node[data-node-id]');
+  await expect(nodes.first()).toBeVisible({ timeout: 45_000 });
+
+  // The demo app is consumer -> provider plus the synthetic User node, so a
+  // correctly drawn graph has several nodes and at least one edge. Asserting
+  // the edge matters: nodes render even when no call between them exists,
+  // which is the break a service map is meant to reveal.
+  expect(await nodes.count()).toBeGreaterThan(1);
+  await expect(page.locator('.sm-edge').first()).toBeVisible();
+
+  expect(crashes, 'an uncaught error during mount blanks the page').toEqual([]);
+});
+
+test('the logs tab returns log lines from the demo app', async ({ page }) => {
+  const crashes: string[] = [];
+  page.on('pageerror', (e) => crashes.push(e.message));
+
+  await page.goto(`/layer/${LAYER}/logs`);
+
+  // Same trailing-control contract as traces: the tab owns its own time range
+  // and waits for an explicit Run query rather than firing on navigation.
+  const run = page.locator('button.lg-run-btn');
+  await expect(run).toBeEnabled();
+  await run.click();
+
+  const rows = page.locator('.lg-stream .lg-row');
+  await expect(rows.first()).toBeVisible({ timeout: 45_000 });
+  // Content, not just a row: an empty stream still renders its container.
+  await expect(rows.first().locator('.lg-content')).not.toBeEmpty();
+
+  expect(crashes).toEqual([]);
+});

--- a/test/e2e/playwright/tsconfig.json
+++ b/test/e2e/playwright/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["specs/**/*", "playwright.config.ts"],
+  "exclude": ["node_modules", "playwright-report", "test-results"]
+}

--- a/test/e2e/script/Dockerfile.demo-service
+++ b/test/e2e/script/Dockerfile.demo-service
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,11 +13,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-packages:
-  - "apps/*"
-  - "packages/*"
-  # The e2e suite is a workspace package so `pnpm -r run type-check` covers
-  # its specs. It ships nothing: no build, no test:unit, dev-only deps — so
-  # it stays out of the packaged artifact and the binary LICENSE.
-  - "test/e2e/playwright"
+# Instrumented demo service = apache/skywalking's published e2e service jar
+# running on apache/skywalking-java's published agent image.
+#
+# Upstream's own compose bind-mounts a Maven-built jar, which would force a
+# JDK + `./mvnw` + an upstream checkout into this repo's CI. Both halves are
+# published images, so joining them here gets the identical result from
+# registry pulls alone.
+#
+# The agent image sets JAVA_TOOL_OPTIONS=-javaagent:/skywalking/agent/... , so
+# the service is instrumented without a command-line flag here.
+
+ARG AGENT_IMAGE
+ARG APP_IMAGE
+
+FROM ${APP_IMAGE} AS app
+
+FROM ${AGENT_IMAGE}
+COPY --from=app /app.jar /app.jar
+CMD ["java", "-jar", "/app.jar"]

--- a/test/e2e/script/docker-compose/base-compose.yml
+++ b/test/e2e/script/docker-compose/base-compose.yml
@@ -1,0 +1,126 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Service definitions shared by every case, in the shape of
+# apache/skywalking's test/e2e-v2/script/docker-compose/base-compose.yml.
+#
+# A case never redefines a service — it `extends` the one it needs and adds
+# only what is case-specific (ports to publish, extra env, depends_on).
+# `extends` deliberately does NOT carry depends_on or volumes_from, so each
+# case declares its own ordering; that is upstream's convention too.
+#
+# Ports are exposed, not published: infra-e2e maps them to ephemeral host
+# ports and exports ${<service>_host} / ${<service>_<port>} for the verify
+# cases to address. Hard-coding host ports here would make two cases running
+# back to back collide.
+
+services:
+  banyandb:
+    image: "ghcr.io/apache/skywalking-banyandb:${SW_BANYANDB_COMMIT}"
+    networks: [e2e]
+    expose: ["17912", "17913"]
+    command: standalone --measure-metadata-cache-wait-duration 1m --stream-metadata-cache-wait-duration 1m
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 17912"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  oap:
+    image: "ghcr.io/apache/skywalking/oap:${SW_OAP_COMMIT}"
+    networks: [e2e]
+    expose: ["11800", "12800", "17128"]
+    environment:
+      SW_HEALTH_CHECKER: default
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      # Without a LAL rule OAP accepts log records and drops them, so the Logs
+      # tab is empty even though the agent is reporting correctly. Enabled for
+      # every case: the demo app already emits logs, so this costs nothing and
+      # spares a whole extra stack just to see them.
+      SW_LOG_LAL_FILES: horizon-e2e
+    volumes:
+      - ./lal.yaml:/skywalking/config/lal/horizon-e2e.yaml
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/11800"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+      # OAP installs ~3000 BanyanDB measure schemas at boot; on a rate-limited
+      # daemon (Docker Desktop) that runs 60-120s before the gRPC port opens.
+      # Without this window the failed probes burn the retry budget.
+      start_period: 90s
+
+  provider:
+    image: "horizon-e2e-demo-provider:${SW_E2E_SERVICE_COMMIT}"
+    pull_policy: never
+    networks: [e2e]
+    expose: ["9090"]
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_AGENT_NAME: e2e-service-provider
+      SW_AGENT_INSTANCE_NAME: provider1
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_METER_ACTIVE: 'false'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9090"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  consumer:
+    image: "horizon-e2e-demo-consumer:${SW_E2E_SERVICE_COMMIT}"
+    pull_policy: never
+    networks: [e2e]
+    expose: ["9092"]
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap:11800
+      SW_AGENT_NAME: e2e-service-consumer
+      SW_AGENT_INSTANCE_NAME: consumer1
+      SW_LOGGING_OUTPUT: CONSOLE
+      SW_METER_ACTIVE: 'false'
+      PROVIDER_URL: http://provider:9090
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9092"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  horizon:
+    image: "${HORIZON_E2E_IMAGE}"
+    # Built from this checkout, never pulled — a pull here would silently test
+    # someone else's build.
+    pull_policy: never
+    networks: [e2e]
+    expose: ["8081"]
+    environment:
+      HORIZON_OAP_QUERY_URL: http://oap:12800
+      HORIZON_OAP_ADMIN_URL: http://oap:17128
+      # Default mode, stated explicitly because it is the contract under test:
+      # Horizon seeds the bundle into OAP's ui_template store at boot and then
+      # renders only what OAP holds. A template-store regression must fail the
+      # suite, not fall back to the disk bundle.
+      HORIZON_TEMPLATES_MODE: live
+      HORIZON_AUTH_BACKEND: local
+      HORIZON_AUTH_LOCAL_USERS: '[{"username":"${HORIZON_E2E_USER}","passwordHash":"${HORIZON_E2E_PASSWORD_HASH}","roles":["admin"]}]'
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8081/api/health"]
+      interval: 5s
+      timeout: 30s
+      retries: 60
+
+networks:
+  e2e:

--- a/test/e2e/script/docker-compose/lal.yaml
+++ b/test/e2e/script/docker-compose/lal.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# LAL rules for the fixture, mounted into OAP by base-compose. Without these
+# OAP accepts log records and drops them, so the Logs tab has nothing to show
+# even though the agent is reporting correctly.
+#
+# Same rule apache/skywalking's log case uses. `abortOnFailure false` keeps
+# lines that do not match the pattern instead of discarding them — for a test
+# fixture, persisting everything is what we want.
+
+rules:
+  - name: horizon-e2e
+    layer: GENERAL
+    dsl: |
+      filter {
+        text {
+          abortOnFailure false
+          regexp $/(?s)(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}) \[TID:(?<tid>.+?)] \[(?<thread>.+?)] (?<level>\w{4,}) (?<logger>.{1,36}) (?<msg>.+)/$
+        }
+        extractor {
+          metrics {
+            timestamp log.timestamp as Long
+            labels level: parsed.level, service: log.service, instance: log.serviceInstance
+            name "log_count"
+            value 1
+          }
+        }
+        sink {
+        }
+      }

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Pinned images, loaded by every case through `init-system-environment` —
+# the same role apache/skywalking's test/e2e-v2/script/env plays there.
+#
+# Everything the fixture runs on is a published apache image; nothing is built
+# from an upstream checkout, so this file plus the compose files is the whole
+# dependency on the SkyWalking repo.
+#
+# Bumping: pick a commit SHA from the relevant upstream master and confirm the
+# tag exists before committing it —
+#
+#     docker manifest inspect ghcr.io/apache/skywalking/oap:<sha>
+#
+# NEVER move these to `latest`. A `latest` here means an unrelated push to an
+# upstream master can turn Horizon's CI red with no Horizon commit involved,
+# and the failure reads as our regression.
+
+# OAP. Must be at or after 5b481a41a9 (#13877), which added the
+# server-admin/ui-management module Horizon's template store talks to on the
+# admin host. Before that commit `templates.mode: live` cannot work.
+SW_OAP_COMMIT=c66a476a994a2ce9c89cc955166420f9f3259a0a
+
+# BanyanDB — the storage every case runs on. OAP's own default selector is
+# banyandb, so no SW_STORAGE override is needed anywhere.
+SW_BANYANDB_COMMIT=d552528a6f1571c26cd449b711db8f7351ada73e
+
+# Java agent image. Carries the agent at /skywalking/agent and presets
+# JAVA_TOOL_OPTIONS, so the demo services need no -javaagent of their own.
+SW_AGENT_JAVA_COMMIT=ac0df43d7140e726eba9e5e5b1b75cf364c71dff
+SW_AGENT_JDK_VERSION=17
+
+# The demo app: apache/skywalking's own e2e provider/consumer services,
+# published as images so no Maven build is needed here. Tagged from the last
+# master push that touched test/e2e-v2/java-test-service.
+SW_E2E_SERVICE_COMMIT=95a296e2c810e6280b16975dd411e9c595a16836
+
+# swctl, the project's own CLI — used for the fixture sanity check that asks
+# OAP directly what it knows, bypassing Horizon. Built from source because
+# skywalking-cli publishes no binaries; the latest release tag (0.14.0) long
+# predates this commit, so a tag here would be a downgrade.
+SW_CTL_COMMIT=85e5afdb3d55c6e5af66a472c3fe8ac024d11690
+
+# The browser runs INSIDE this image, in CI and on a laptop alike, so the e2e
+# environment is locked to one Ubuntu. Chromium's rendering, fonts and system
+# libraries are then identical everywhere, and a local run reproduces CI
+# exactly rather than approximately. Must match the @playwright/test version
+# in test/e2e/playwright/package.json.
+SW_PLAYWRIGHT_IMAGE=mcr.microsoft.com/playwright:v1.62.1-noble
+
+# ── Horizon under test ──────────────────────────────────────────────────
+# Built from this checkout (`make -C test/e2e image`) or loaded from the CI
+# artifact. Never pulled — compose sets pull_policy: never so a missing build
+# fails loudly instead of silently testing someone else's image.
+HORIZON_E2E_IMAGE=horizon-ui:e2e
+
+# The fixture's only account. The hash is argon2id of HORIZON_E2E_PASSWORD.
+#
+# NOT QUOTED, and nothing in this file may be. infra-e2e reads it by splitting
+# each line on the first `=` and exporting the remainder verbatim — it does no
+# quote stripping and no expansion. Quoting the hash therefore ships the `'`
+# characters into the container as part of the hash, argon2 rejects it, and
+# every authenticated case fails with an empty body rather than a 401 anyone
+# would recognise.
+#
+# The same constraint is why no reader of this file may shell-source it: bash
+# would expand the `$argon2id` / `$v` / `$m` segments to nothing. Read
+# individual keys instead (see script/prepare/build-images.sh).
+HORIZON_E2E_USER=e2e
+HORIZON_E2E_PASSWORD=e2e-passw0rd
+HORIZON_E2E_PASSWORD_HASH=$argon2id$v=19$m=65536,t=3,p=4$K/f0dJqlI/c1I6RPxNhTPg$sZ2NcLuSPL/o4bqNrARetaLVp4MDmV0xzxdwyYUKh+U

--- a/test/e2e/script/prepare/build-images.sh
+++ b/test/e2e/script/prepare/build-images.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Builds the two images the compose files reference but no registry carries:
+# the instrumented demo services, and Horizon itself.
+#
+# Run before any case. CI runs it as a workflow step; locally it is
+# `make -C test/e2e images`. Both paths go through this script so a case can
+# never be run against an image built a different way.
+
+set -eu
+
+here=$(cd "$(dirname "$0")/.." && pwd)   # test/e2e/script
+root=$(cd "${here}/../../.." && pwd)     # repo root
+
+# Read one key from script/env exactly the way infra-e2e does: split on the
+# first `=`, take the rest verbatim. Sourcing the file instead would let bash
+# expand the `$` segments of the argon2 hash to nothing — see the note there.
+val() {
+  grep -E "^$1=" "${here}/env" | head -1 | cut -d= -f2-
+}
+
+SW_AGENT_JAVA_COMMIT=$(val SW_AGENT_JAVA_COMMIT)
+SW_AGENT_JDK_VERSION=$(val SW_AGENT_JDK_VERSION)
+SW_E2E_SERVICE_COMMIT=$(val SW_E2E_SERVICE_COMMIT)
+HORIZON_E2E_IMAGE=$(val HORIZON_E2E_IMAGE)
+
+AGENT_IMAGE="ghcr.io/apache/skywalking-java/skywalking-java:${SW_AGENT_JAVA_COMMIT}-java${SW_AGENT_JDK_VERSION}"
+
+build_demo() {
+  local role="$1"
+  echo "▸ building horizon-e2e-demo-${role}:${SW_E2E_SERVICE_COMMIT}"
+  docker build \
+    --build-arg "AGENT_IMAGE=${AGENT_IMAGE}" \
+    --build-arg "APP_IMAGE=ghcr.io/apache/skywalking/e2e-service-${role}:${SW_E2E_SERVICE_COMMIT}" \
+    -t "horizon-e2e-demo-${role}:${SW_E2E_SERVICE_COMMIT}" \
+    -f "${here}/Dockerfile.demo-service" \
+    "${here}"
+}
+
+build_demo provider
+build_demo consumer
+
+# Horizon last: it is the slow one, and a failure in the cheap builds above
+# should surface first.
+if [ "${SKIP_HORIZON_IMAGE:-}" = "true" ]; then
+  echo "▸ skipping ${HORIZON_E2E_IMAGE} (SKIP_HORIZON_IMAGE=true)"
+else
+  echo "▸ building ${HORIZON_E2E_IMAGE} from ${root}"
+  docker build -t "${HORIZON_E2E_IMAGE}" "${root}"
+fi
+
+echo "images ready"

--- a/test/e2e/script/prepare/dev-compose.sh
+++ b/test/e2e/script/prepare/dev-compose.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#     dev-compose.sh <case> <compose args...>
+#
+# Runs docker compose for a case the way infra-e2e does, for the `make dev`
+# stack that outlives the command that started it.
+#
+# Why not `docker compose --env-file script/env`: compose INTERPOLATES `$` in
+# values read from an env file, so the argon2 hash collapses to blanks
+# ("argon2id variable is not set") and every login fails. infra-e2e instead
+# splits each line on the first `=` and exports the value verbatim. Compose
+# does not re-interpolate values substituted from the environment, so loading
+# them that way and leaving --env-file off reproduces infra-e2e's behaviour
+# exactly — one parsing convention across the whole tree, which is what
+# script/env documents.
+
+set -eu
+
+CASE="${1:?usage: dev-compose.sh <case> <compose args...>}"
+shift
+
+here=$(cd "$(dirname "$0")/../.." && pwd)   # test/e2e
+
+while IFS= read -r line; do
+  case "${line}" in
+    '#'* | '') continue ;;
+  esac
+  key=${line%%=*}
+  val=${line#*=}
+  [ "${key}" = "${line}" ] && continue
+  export "${key}=${val}"
+done < "${here}/script/env"
+
+exec docker compose \
+  -p horizon-e2e-dev \
+  -f "${here}/cases/${CASE}/docker-compose.yml" \
+  "$@"

--- a/test/e2e/script/prepare/horizon-get.sh
+++ b/test/e2e/script/prepare/horizon-get.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,11 +14,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+#     horizon-get.sh <base-url> <path>
+#
+# Signs in and GETs an authenticated BFF route, printing the body on stdout.
+# Every Horizon query route is behind a session cookie, so a verify case
+# cannot simply curl one.
 
-packages:
-  - "apps/*"
-  - "packages/*"
-  # The e2e suite is a workspace package so `pnpm -r run type-check` covers
-  # its specs. It ships nothing: no build, no test:unit, dev-only deps — so
-  # it stays out of the packaged artifact and the binary LICENSE.
-  - "test/e2e/playwright"
+set -eu
+
+BASE="${1:?usage: horizon-get.sh <base-url> <path>}"
+PATH_="${2:?usage: horizon-get.sh <base-url> <path>}"
+
+USER="${HORIZON_E2E_USER:-e2e}"
+PASSWORD="${HORIZON_E2E_PASSWORD:-e2e-passw0rd}"
+
+JAR=$(mktemp)
+trap 'rm -f "${JAR}"' EXIT
+
+curl -sSf -c "${JAR}" -X POST "${BASE}/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"${USER}\",\"password\":\"${PASSWORD}\"}" > /dev/null
+
+curl -sSf -b "${JAR}" "${BASE}${PATH_}"

--- a/test/e2e/script/prepare/install.sh
+++ b/test/e2e/script/prepare/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Per-tool installer for the setup steps, same entry shape as
+# apache/skywalking's test/e2e-v2/script/prepare/setup-e2e-shell/install.sh:
+#
+#     bash test/e2e/script/prepare/install.sh <tool>
+#
+# Deliberate difference from upstream: yq comes from a prebuilt release rather
+# than `go install`. Upstream already needs a Go toolchain for its own build;
+# this repo does not, and requiring one to run the UI's e2e locally on a
+# laptop is a cost with no return.
+
+set -eu
+
+NAME="${1:?usage: install.sh <yq|swctl|playwright>}"
+BIN_DIR=/tmp/skywalking-infra-e2e/bin
+mkdir -p "${BIN_DIR}"
+
+here=$(cd "$(dirname "$0")/../.." && pwd)   # test/e2e
+root=$(cd "${here}/../.." && pwd)           # repo root
+
+case "${NAME}" in
+  yq)
+    if command -v yq > /dev/null 2>&1; then
+      echo "yq already installed: $(command -v yq)"
+      exit 0
+    fi
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$(uname -m)" in
+      x86_64 | amd64) arch=amd64 ;;
+      arm64 | aarch64) arch=arm64 ;;
+      *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    curl -sSfLo "${BIN_DIR}/yq" \
+      "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_${os}_${arch}"
+    chmod +x "${BIN_DIR}/yq"
+    echo "installed yq to ${BIN_DIR}/yq"
+    ;;
+
+  swctl)
+    # skywalking-cli publishes no binaries, so this builds from source like
+    # upstream's installer does — it needs a Go toolchain on PATH. The version
+    # is pinned in script/env; re-install when the installed one does not
+    # match, otherwise a stale swctl from another project silently wins.
+    ctl_commit=$(grep -E '^SW_CTL_COMMIT=' "${here}/script/env" | head -1 | cut -d= -f2-)
+    if command -v swctl > /dev/null 2>&1 && swctl --version 2>/dev/null | grep -q "${ctl_commit:0:7}"; then
+      echo "swctl already at ${ctl_commit:0:7}"
+      exit 0
+    fi
+    tmp=/tmp/skywalking-infra-e2e/swctl
+    mkdir -p "${tmp}" && cd "${tmp}"
+    curl -sSkLo skywalking-cli.tar.gz \
+      "https://github.com/apache/skywalking-cli/archive/${ctl_commit}.tar.gz"
+    tar -zxf skywalking-cli.tar.gz --strip=1
+    VERSION="${ctl_commit}" make install DESTDIR="${BIN_DIR}"
+    echo "installed swctl to ${BIN_DIR}/swctl"
+    ;;
+
+  playwright)
+    # Clear the fail-fast markers playwright.sh writes. They must not survive
+    # from a previous run on the same machine, or the browser cases would
+    # short-circuit to "failed" before running once.
+    rm -f /tmp/skywalking-infra-e2e/playwright-*.failed
+
+    # The suite runs in the pinned Ubuntu image, so nothing is installed on
+    # the host — pre-pull it here to keep the pull out of the timed case.
+    image=$(grep -E '^SW_PLAYWRIGHT_IMAGE=' "${here}/script/env" | head -1 | cut -d= -f2-)
+    docker pull -q "${image}" > /dev/null
+    echo "browser image ready: ${image}"
+    ;;
+
+  *)
+    echo "unknown tool: ${NAME}" >&2
+    exit 1
+    ;;
+esac

--- a/test/e2e/script/prepare/log-traffic.sh
+++ b/test/e2e/script/prepare/log-traffic.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#     log-traffic.sh <provider-base-url> [count]
+#
+# Fires a burst at the demo app's log-emitting endpoint.
+#
+# Why a burst here rather than the `trigger` block: a case gets exactly one
+# trigger, and that one is spent on the consumer -> provider call, which is
+# what produces the service and instance topology. Logs come from a DIFFERENT
+# endpoint on the provider, so they need their own nudge. A burst is enough —
+# logs are queried over a 30-minute window, so they do not need topping up the
+# way the metrics widgets do.
+
+set -eu
+
+BASE="${1:?usage: log-traffic.sh <provider-base-url> [count]}"
+COUNT="${2:-30}"
+
+sent=0
+for _ in $(seq 1 "${COUNT}"); do
+  if curl -sf -o /dev/null "${BASE}/logs/trigger"; then
+    sent=$(( sent + 1 ))
+  fi
+  sleep 1
+done
+
+echo "log traffic: ${sent}/${COUNT} ok"
+
+if [ "${sent}" -eq 0 ]; then
+  echo "ERROR: the demo app never served /logs/trigger — no logs will exist." >&2
+  exit 1
+fi

--- a/test/e2e/script/prepare/playwright.sh
+++ b/test/e2e/script/prepare/playwright.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#     playwright.sh <project>
+#
+# Runs one Playwright project and reduces it to the single line infra-e2e
+# compares against an `expected` file.
+#
+# The browser runs INSIDE the pinned Ubuntu image, never on the host. The e2e
+# environment is therefore one platform everywhere: a laptop run reproduces CI
+# exactly instead of approximately, and nothing depends on what the developer
+# happens to have installed. It also removes the whole class of "passes on my
+# machine" caused by fonts, system libraries or a differently-patched Chromium.
+#
+# The container joins the fixture's own compose network and reaches Horizon by
+# SERVICE NAME, so no host port mapping is involved and no URL has to be
+# threaded through from infra-e2e.
+#
+# Playwright's own output goes to STDERR on purpose: infra-e2e parses stdout as
+# YAML and diffs it, so a stray reporter line there would fail the case with a
+# diff instead of the real error. Report, traces and screenshots land in
+# test/e2e/playwright/{playwright-report,test-results} for the CI artifact.
+
+set -eu
+
+PROJECT="${1:?usage: playwright.sh <project>}"
+
+here=$(cd "$(dirname "$0")/../.." && pwd)   # test/e2e
+root=$(cd "${here}/../.." && pwd)           # repo root
+marker="/tmp/skywalking-infra-e2e/playwright-${PROJECT}.failed"
+
+image=$(grep -E '^SW_PLAYWRIGHT_IMAGE=' "${here}/script/env" | head -1 | cut -d= -f2-)
+
+# infra-e2e's retry budget is global to `verify`, and VerifyCase carries no
+# per-case override — so a genuinely failing browser project gets re-run for
+# the whole budget. That turns a real regression from a 20-second answer into
+# a quarter of an hour, and overwrites the artifacts each round, so what
+# survives is the LAST failure rather than the first.
+#
+# The budget exists for the data-readiness gates ahead of this case, which do
+# need it. A browser suite does not: if the assertions failed once against a
+# fixture already proven ready, running them again changes nothing. Record the
+# first failure and short-circuit every later attempt, which also preserves
+# the screenshots and trace taken closest to the cause.
+if [ -f "${marker}" ]; then
+  echo "passed: false"
+  exit 1
+fi
+
+# Discover the fixture's network from the running horizon container rather
+# than deriving it from a project name — infra-e2e and the `make dev` targets
+# use different compose projects, and both must work.
+container=$(docker ps --filter 'label=com.docker.compose.service=horizon' \
+                      --format '{{.Names}}' | head -1)
+if [ -z "${container}" ]; then
+  echo "passed: false"
+  echo "ERROR: no running horizon container — is the fixture up?" >&2
+  exit 1
+fi
+network=$(docker inspect "${container}" \
+  --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}')
+
+# The whole repo is mounted, not just test/: pnpm links node_modules into the
+# workspace root store, so a narrower mount leaves the symlinks dangling.
+if docker run --rm \
+     --network "${network}" \
+     -v "${root}:/work" -w /work/test/e2e/playwright \
+     -e HORIZON_BASE_URL=http://horizon:8081 \
+     -e CI=1 \
+     "${image}" \
+     npx playwright test --project="${PROJECT}" >&2; then
+  echo "passed: true"
+else
+  mkdir -p "$(dirname "${marker}")"
+  : > "${marker}"
+  echo "passed: false"
+  exit 1
+fi


### PR DESCRIPTION
Two changes to CI, both about making it say something true.

## 1. Ten jobs become three

Eight of the ten jobs did the same checkout, the same `pnpm install`, and then a gate that finishes in seconds. Two were duplicate work outright: `pnpm package` already builds the three `packages/*`, the BFF bundle and the Vite UI, so `build-ui` / `build-bff` recompiled what packaging compiles anyway; and `pnpm lint` already ends with `templates:validate`, which is all the `templates` job ran.

| before | after |
| --- | --- |
| `license-header` | `License header` — unchanged, needs no Node or install so it stays parallel |
| `dependency-license`, `type-check`, `build-ui`, `build-bff`, `test`, `lint`, `templates`, `package` | `Build and check` — one job, steps cheapest-first |
| `required` | `Required` — rollup, unchanged contract |

No gate was dropped, and the `Required` context `.asf.yaml` gates on is untouched.

One real ordering constraint the parallel layout hid: `collect-dist-licenses.mjs` writes `dist/LICENSE`, `dist/NOTICE` and `dist/.dependency-report.json`, and `pnpm package` begins by `rm -rf dist`. A naive sequential merge in the old order would have wiped the artifact upload's own inputs. `licenses:bin:check` now runs after packaging — also the more truthful order, since the uploaded report then describes the artifact that was actually built.

## 2. An end-to-end suite that runs Horizon against a real OAP

Nothing in CI ran Horizon against a backend. A green type-check proves the code compiles; it does not prove a widget resolves its MQE against live data, that the trace list renders what the BFF returned, or that a view mounts at all.

`test/e2e/` stands up BanyanDB + OAP + two instrumented demo services + Horizon, and verifies **both halves**: Playwright's `request` fixture asserts the BFF's HTTP surface, headless Chromium drives the rendered app. They are separate projects sharing one login, so a failure says which side broke — a route returning correct JSON into a view that throws on mount passes every API assertion and is blank for the operator.

### Reuse

Every upstream image is pinned by commit SHA in `test/e2e/env`, in the same shape as `apache/skywalking`'s `test/e2e-v2/script/env`. The demo app is that repo's own e2e provider/consumer.

Upstream's compose bind-mounts a Maven-built jar, which would have dragged a JDK, `mvn` and an upstream checkout into this repo's CI. Both halves are published images — `e2e-service-{provider,consumer}` carries the jar, `skywalking-java` carries the agent and already sets `JAVA_TOOL_OPTIONS` — so a two-line Dockerfile joins them and the entire dependency on the SkyWalking repo becomes registry pulls.

Every pin resolves on `linux/arm64` as well as `amd64`, so the suite runs natively on a laptop, not only in CI:

```bash
cd test/e2e
pnpm e2e:image && pnpm e2e:up && pnpm e2e:traffic && pnpm e2e:test
```

The OAP pin must stay at or after `5b481a41a9` (#13877) — the commit that added the `ui-management` module the template store talks to. That is also why `templates.mode: live` is the mode under test rather than sidestepped: Horizon seeds the bundle into OAP at boot and renders only what OAP holds, so a template-store regression fails the suite instead of falling back to the disk bundle.

### Two behaviours found by running it, not by reading the code

Both are now encoded so they cannot become flakes:

- The service roster is served from a catalog cached with a **60s TTL**, so for up to a minute after the agents register, a correct Horizon still answers with an empty roster. `traffic.sh` gates on Horizon's own view of the fixture, so an empty roster during the suite means a real regression rather than a race.

- The traces scatter chart carries the endpoint name inside an **SVG `<title>`**. A plain text query matches it on a page whose trace list is empty, so the trace assertions bind to list rows instead.

A third was my own: `request.newContext()` inherits `storageState` from the project's `use`, so an "anonymous" context is still signed in — the auth-gate test would have passed against a Horizon with no auth at all.

### Scope

`e2e-core` is **not** in the `Required` rollup yet. It reports on every PR and a red run is a real signal, but a suite this young blocking every merge trades one class of bug for a worse one — people learn to re-run it rather than read it. Promoting it is two lines once it has held green across real PRs.

Rover / eBPF cases are out of scope here: they need a Linux kernel and cannot run on a laptop. Nothing in the core fixture uses them.

## Validation

- The consolidated job's step sequence run locally against a clean install: `pnpm package` → `pnpm licenses:bin:check` succeeds in that order, all three report files land beside `dist/server.js`, and the boot smoke passes against that same `dist/`.
- The e2e suite run **cold** on a laptop — `down` → `up` → traffic (25 requests, 0 failed) → catalog gate → **22 passed**.
- `pnpm lint`, `pnpm -r run type-check` (including the new specs) and `license-eye header check` all green.