### PR TITLE
ci: cache swctl, cover DSL from core, and add the ES and Zipkin e2e deployments

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,17 +59,27 @@
 #                                            render unless Horizon seeded the
 #                                            bundle into OAP and read it back.
 #
-#   dsl         —  (same stack, admin port)  DSL management + live debugger     PLANNED
-#                                            against OAP's admin host, which
-#                                            core already exposes. Folds in.
+#               (DSL management and the live debugger fold into core too: both
+#               OAP modules are on by default and core already exposes the
+#               admin host, so they cost no extra containers.)
 #
-#   zipkin      Zipkin receiver              /api/zipkin/* and the              PLANNED
-#                                            zipkin-trace tab
+#   zipkin      Zipkin receiver              Zipkin ingestion and query. The     ACTIVE
+#                                            demo app here reports Zipkin
+#                                            spans straight to OAP rather than
+#                                            through a SkyWalking agent, and
+#                                            Horizon reads them over the
+#                                            Zipkin-compatible API, not
+#                                            GraphQL — neither is reachable
+#                                            from core.
 #   browser     client-js app                Browser Errors tab, source-map     PLANNED
 #                                            de-minification
-#   es          ElasticSearch storage        trace v1 (the ONLY path that       PLANNED
-#                                            reaches it — v2 is BanyanDB-only)
-#                                            and ES-only fuzzy log query
+#   es          ElasticSearch storage        trace v1 — the ONLY path that       ACTIVE
+#                                            reaches it, since v2 is
+#                                            BanyanDB-only. Deliberately not a
+#                                            copy of core: re-asserting every
+#                                            signal on a second backend would
+#                                            double the runtime to re-prove
+#                                            what storage does not affect.
 #   deployment  BanyanDB CLUSTER             the Deployment component, which    PLANNED
 #                                            visualises BanyanDB self-
 #                                            observability. Needs liaison +
@@ -114,6 +124,10 @@ jobs:
         case:
           - name: core (BanyanDB)
             config: test/e2e/cases/core/e2e.yaml
+          - name: es (ElasticSearch)
+            config: test/e2e/cases/es/e2e.yaml
+          - name: zipkin (receiver + query)
+            config: test/e2e/cases/zipkin/e2e.yaml
     steps:
       - uses: actions/checkout@v6
         with:
@@ -124,6 +138,21 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+
+      # swctl has no published binaries, so the case builds it from source —
+      # about a minute, and the largest fixed cost in the run. The binary only
+      # changes when the pin does, so key the cache on the pin itself rather
+      # than on the file that holds it: bumping an unrelated image pin should
+      # not throw the compiler back at us.
+      - name: Resolve the pinned swctl commit
+        id: pins
+        run: |
+          echo "swctl=$(grep -E '^SW_CTL_COMMIT=' test/e2e/script/env | head -1 | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+      - name: Cache swctl
+        uses: actions/cache@v4
+        with:
+          path: /tmp/skywalking-infra-e2e/bin/swctl
+          key: swctl-${{ runner.os }}-${{ steps.pins.outputs.swctl }}
 
       # Horizon and the instrumented demo services. Built here rather than
       # pulled: the point is to test THIS commit, and compose sets

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -17,10 +17,13 @@ test/e2e/
     Dockerfile.demo-service      agent image + upstream service jar
     prepare/                     installers and helpers used by cases
   cases/
-    core/
-      e2e.yaml                   setup / trigger / verify / cleanup
+    core/                        the baseline stack — traces, metrics, logs,
+      e2e.yaml                   topology, events, DSL, and the UI for each
       docker-compose.yml         extends the base; adds ports + depends_on
       expected/                  expected output per verify case
+    es/                          ElasticSearch storage — the only path that
+                                 reaches Horizon's pre-v2 trace query
+    zipkin/                      Zipkin receiver + Zipkin query surface
   playwright/                    the Playwright project: config + specs
 ```
 
@@ -88,7 +91,7 @@ Cases needing **rover / eBPF** cannot run on macOS: eBPF needs a Linux kernel, a
 ## Adding a case
 
 1. `mkdir test/e2e/cases/<name>` with a `docker-compose.yml` that `extends` the base and an `e2e.yaml`.
-2. Add expected files under `cases/<name>/expected/`.
+2. Add expected files under `cases/<name>/expected/`. **Write them before the first run** — a missing expected file is retried for the whole budget and can never succeed, so a typo costs the full retry window rather than failing fast.
 3. Add one entry to the `case:` matrix in `.github/workflows/e2e.yaml`, and a row to the case/feature matrix in its header comment.
 
 If the case needs UI coverage, add specs under `playwright/specs/` and a Playwright project, then call `script/prepare/playwright.sh <project> <url>` from a verify case.

--- a/test/e2e/cases/es/docker-compose.yml
+++ b/test/e2e/cases/es/docker-compose.yml
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The same stack as `core`, on ElasticSearch instead of BanyanDB.
+#
+# It earns a deployment of its own for one reason: Trace Query v2 is
+# BanyanDB-only, so this is the ONLY configuration where Horizon's
+# hasQueryTracesV2Support probe comes back false and the v1 query path runs.
+# No amount of BanyanDB testing reaches that branch.
+
+services:
+  es:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: es
+
+  oap:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: oap
+    # `extends` MERGES environment, so the BanyanDB target inherited from the
+    # base stays present and unused — SW_STORAGE is what selects the backend.
+    environment:
+      SW_STORAGE: elasticsearch
+      SW_STORAGE_ES_CLUSTER_NODES: es:9200
+    ports:
+      - 12800
+      - 17128
+    depends_on:
+      es:
+        condition: service_healthy
+
+  provider:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: provider
+    ports:
+      - 9090
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  consumer:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: consumer
+    ports:
+      - 9092
+    depends_on:
+      provider:
+        condition: service_healthy
+
+  horizon:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: horizon
+    ports:
+      - 8081
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/es/e2e.yaml
+++ b/test/e2e/cases/es/e2e.yaml
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ElasticSearch storage. Deliberately NOT a copy of `core`: re-asserting every
+# signal on a second backend would double the runtime to re-prove things that
+# do not depend on storage. This case exists for the branch that does — the
+# pre-v2 trace query — plus enough of a smoke test to show the UI still works
+# when the backend changes underneath it.
+#
+# Run it:  e2e run -c test/e2e/cases/es/e2e.yaml
+# Images:  make -C test/e2e images
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 30m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e/script/prepare/install.sh yq
+    - name: install swctl
+      command: bash test/e2e/script/prepare/install.sh swctl
+    - name: prepare browser image
+      command: bash test/e2e/script/prepare/install.sh playwright
+
+trigger:
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${consumer_host}:${consumer_9092}/users
+  method: POST
+  body: '{"id":"123","name":"skywalking"}'
+  headers:
+    "Content-Type": "application/json"
+
+verify:
+  retry:
+    count: 40
+    interval: 5s
+  cases:
+    # 1. Fixture sanity straight off OAP, same as core: if this fails the demo
+    #    app or the agent is broken, not Horizon.
+    - query: |
+        swctl --display json --base-url=http://${oap_host}:${oap_12800}/graphql service ls \
+          | yq -P '{"demoServices": [.[] | select(.name == "e2e-service-provider" or .name == "e2e-service-consumer")] | length}'
+      expected: expected/demo-services.yml
+
+    # 2. Horizon classifies the backend as NOT banyandb. `backend` is a
+    #    capability classification — banyandb / other / unknown, inferred from
+    #    the TTL shape — not a storage name, so ElasticSearch is correctly
+    #    `other` rather than `elasticsearch`. What matters here is that it is
+    #    not banyandb: if it were, the storage override silently failed and
+    #    every case below would be re-testing core on the wrong stack.
+    - query: |
+        bash test/e2e/script/prepare/horizon-get.sh \
+          "http://${horizon_host}:${horizon_8081}" /api/oap/info \
+          | yq -P '{"reachable": .reachable, "backend": .backend}'
+      expected: expected/backend-es.yml
+
+    # 3. Metrics readiness, for the same reason core needs it: OAP persists on
+    #    a ~25s cycle, so without this the wait lands on the browser case.
+    - query: |
+        swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql \
+          metrics exec --expression=service_cpm --service-name=e2e-service-provider
+      expected: expected/metrics-has-value.yml
+
+    # 4. THE reason this case exists: on a non-BanyanDB backend Horizon's
+    #    capability probe finds no Trace Query v2, and the trace list must come
+    #    back over the v1 API instead. `core` can never reach this branch.
+    - query: |
+        bash test/e2e/script/prepare/horizon-post.sh \
+          "http://${horizon_host}:${horizon_8081}" /api/layer/general/traces \
+          '{"windowMinutes":30,"pageSize":5}' \
+          | yq -P '{"api": .native.api, "hasTraces": (.native.traces | length > 0)}'
+      expected: expected/trace-api-v1.yml
+
+    # 5. The UI still renders against a different backend. Only the shell and
+    #    layer journeys — the signal-specific tabs are core's job.
+    - query: |
+        bash test/e2e/script/prepare/playwright.sh ui
+      expected: expected/passed.yml
+
+cleanup:
+  on: always

--- a/test/e2e/cases/es/expected/backend-es.yml
+++ b/test/e2e/cases/es/expected/backend-es.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+reachable: true
+backend: other

--- a/test/e2e/cases/es/expected/demo-services.yml
+++ b/test/e2e/cases/es/expected/demo-services.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+demoServices: 2

--- a/test/e2e/cases/es/expected/metrics-has-value.yml
+++ b/test/e2e/cases/es/expected/metrics-has-value.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Asserts only that PERSISTED data exists: at least one bucket carries a value.
+#
+# Deliberately does NOT pin the newest bucket. OAP persists on a ~25s cycle and
+# aggregates into minute buckets, so whether the last bucket is null or filled
+# depends purely on when the query lands relative to that cycle — upstream's
+# copy of this file asserts a trailing null, which is a coin flip rather than a
+# contract. `contains` means "the actual data includes at least this", so one
+# filled bucket is the whole assertion.
+debuggingtrace: null
+type: TIME_SERIES_VALUES
+results:
+  {{- contains .results }}
+  - metric:
+      labels: []
+    values:
+      {{- contains .values }}
+      - id: {{ notEmpty .id }}
+        value: {{ notEmpty .value }}
+        owner: null
+        traceid: null
+      {{- end}}
+  {{- end}}
+error: null

--- a/test/e2e/cases/es/expected/passed.yml
+++ b/test/e2e/cases/es/expected/passed.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+passed: true

--- a/test/e2e/cases/es/expected/trace-api-v1.yml
+++ b/test/e2e/cases/es/expected/trace-api-v1.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+api: queryBasicTraces
+hasTraces: true

--- a/test/e2e/cases/zipkin/docker-compose.yml
+++ b/test/e2e/cases/zipkin/docker-compose.yml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Zipkin: a different RECEIVER and a different query surface, which is why it
+# earns its own deployment. The demo app here reports Zipkin spans directly to
+# OAP rather than through a SkyWalking agent, and Horizon reads them over the
+# Zipkin query API instead of the GraphQL trace API.
+
+services:
+  banyandb:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: banyandb
+
+  oap:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: oap
+    environment:
+      # Receiver takes spans on 9411; the Zipkin-compatible query API is
+      # served on 9412, which is what Horizon reads.
+      SW_RECEIVER_ZIPKIN: default
+      SW_QUERY_ZIPKIN: default
+    expose:
+      - 9411
+    ports:
+      - 12800
+      - 17128
+      - 9412
+    depends_on:
+      banyandb:
+        condition: service_healthy
+
+  zipkin-backend:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: zipkin-backend
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  zipkin-frontend:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: zipkin-frontend
+    ports:
+      # Published so the trigger can drive it from the host.
+      - 8081
+    depends_on:
+      oap:
+        condition: service_healthy
+
+  horizon:
+    extends:
+      file: ../../script/docker-compose/base-compose.yml
+      service: horizon
+    environment:
+      # Without this Horizon probes the default localhost URL, reports
+      # zipkinReachable false, and the whole Zipkin surface stays dark.
+      HORIZON_OAP_ZIPKIN_URL: http://oap:9412/zipkin
+    ports:
+      - 8081
+    depends_on:
+      oap:
+        condition: service_healthy
+
+networks:
+  e2e:

--- a/test/e2e/cases/zipkin/e2e.yaml
+++ b/test/e2e/cases/zipkin/e2e.yaml
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Zipkin ingestion and query. Scoped to what differs from core: the receiver,
+# the Zipkin query surface, and Horizon's reachability probe for it.
+#
+# Run it:  e2e run -c test/e2e/cases/zipkin/e2e.yaml
+# Images:  make -C test/e2e images
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 30m
+  init-system-environment: ../../script/env
+  steps:
+    - name: set PATH
+      command: export PATH=/tmp/skywalking-infra-e2e/bin:$PATH
+    - name: install yq
+      command: bash test/e2e/script/prepare/install.sh yq
+    - name: prepare browser image
+      command: bash test/e2e/script/prepare/install.sh playwright
+
+trigger:
+  # Drives frontend -> backend, which is what produces a two-service Zipkin
+  # trace rather than a single orphan span.
+  action: http
+  interval: 3s
+  times: -1
+  url: http://${zipkin-frontend_host}:${zipkin-frontend_8081}/
+  method: GET
+
+verify:
+  retry:
+    count: 40
+    interval: 5s
+  cases:
+    # 1. Horizon can actually reach OAP's Zipkin query API. If this is false
+    #    every assertion below would fail with an empty list, which reads as
+    #    "no traces" rather than "wrong URL".
+    - query: |
+        bash test/e2e/script/prepare/horizon-get.sh \
+          "http://${horizon_host}:${horizon_8081}" /api/oap/info \
+          | yq -P '{"reachable": .reachable, "zipkinReachable": .zipkinReachable}'
+      expected: expected/zipkin-reachable.yml
+
+    # 2. The receiver accepted the spans and the query API lists both demo
+    #    services — the Zipkin equivalent of core's roster gate.
+    - query: |
+        bash test/e2e/script/prepare/horizon-get.sh \
+          "http://${horizon_host}:${horizon_8081}" /api/zipkin/services \
+          | yq -P '{"hasServices": (. | length > 0)}'
+      expected: expected/has-zipkin-services.yml
+
+cleanup:
+  on: always

--- a/test/e2e/cases/zipkin/expected/has-zipkin-services.yml
+++ b/test/e2e/cases/zipkin/expected/has-zipkin-services.yml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+hasServices: true

--- a/test/e2e/cases/zipkin/expected/zipkin-reachable.yml
+++ b/test/e2e/cases/zipkin/expected/zipkin-reachable.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+reachable: true
+zipkinReachable: true

--- a/test/e2e/playwright/specs/bff/dsl.spec.ts
+++ b/test/e2e/playwright/specs/bff/dsl.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// DSL management and the live debugger, which talk to OAP's ADMIN host rather
+// than the query port. The core fixture already exposes it and both OAP
+// modules (receiver-runtime-rule, dsl-debugging) are on by default, so this
+// needs no fixture of its own.
+//
+// Read-only throughout. Pushing a rule would mutate the OAP the other cases
+// are asserting against, and a hot-update that half-applied would surface as
+// an unrelated failure somewhere else in the run.
+
+test('the OAL catalog lists the shipped rule files', async ({ request: api }) => {
+  const body = await (await api.get('/api/oal/files')).json();
+  expect(body.count).toBeGreaterThan(0);
+  expect(body.files).toContain('oal/core.oal');
+  expect(body.files.length).toBe(body.count);
+});
+
+test('OAL sources carry the metrics the dashboards read', async ({ request: api }) => {
+  const body = await (await api.get('/api/oal/rules')).json();
+  const service = body.sources.find((s: { source: string }) => s.source === 'Service');
+  expect(service, 'the Service scope must be in the OAL catalog').toBeDefined();
+  // service_cpm is what the layer dashboard's traffic widgets read, and what
+  // the metrics readiness gate queries — the two should agree about it
+  // existing.
+  expect(service.metrics).toContain('service_cpm');
+});
+
+test("the LAL catalog shows the fixture's own rule", async ({ request: api }) => {
+  const rules = await (await api.get('/api/catalog/bundled?catalog=lal')).json();
+  const ours = rules.find((r: { name: string }) => r.name === 'horizon-e2e');
+  // Ties the DSL surface to the fixture: this is the very rule mounted into
+  // OAP by base-compose, so seeing it here proves the admin host is reading
+  // the same configuration the log pipeline is running.
+  expect(ours, 'the mounted LAL rule must be visible through DSL management').toBeDefined();
+  expect(ours.kind).toBe('bundled');
+  expect(ours.content).toContain('filter');
+});
+
+test('the rule loader reports as running', async ({ request: api }) => {
+  const body = await (await api.get('/api/catalog/list?catalog=otel-rules')).json();
+  // An `active` of zero means the runtime-rule module never came up, which
+  // would leave every DSL screen looking merely empty rather than broken.
+  expect(body.loaderStats.active).toBeGreaterThan(0);
+  expect(body.loaderStats.pending).toBe(0);
+});
+
+test('rule status refuses an absent or unknown catalog', async ({ request: api }) => {
+  // Both are 400s with distinct codes. Answering either with an empty result
+  // would read as "this catalog has no rules" and hide a typo in a URL.
+  const missing = await api.get('/api/rule/status');
+  expect(missing.status()).toBe(400);
+  expect((await missing.json()).error).toBe('missing_catalog');
+
+  const invalid = await api.get('/api/rule/status?catalog=not-a-catalog');
+  expect(invalid.status()).toBe(400);
+  expect((await invalid.json()).error).toBe('invalid_catalog');
+});
+
+test('the live debugger reports its session list', async ({ request: api }) => {
+  const body = await (await api.get('/api/debug/sessions')).json();
+  expect(Array.isArray(body.sessions)).toBe(true);
+  expect(body.count).toBe(body.sessions.length);
+});

--- a/test/e2e/script/docker-compose/base-compose.yml
+++ b/test/e2e/script/docker-compose/base-compose.yml
@@ -40,6 +40,22 @@ services:
       timeout: 60s
       retries: 120
 
+  # Alternative storage, used only by the case that needs a non-BanyanDB
+  # backend. Cases that do not extend it never start it.
+  es:
+    image: "elastic/elasticsearch:${ES_VERSION}"
+    networks: [e2e]
+    expose: ["9200"]
+    environment:
+      - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - xpack.security.enabled=false
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/9200"]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
   oap:
     image: "ghcr.io/apache/skywalking/oap:${SW_OAP_COMMIT}"
     networks: [e2e]
@@ -121,6 +137,30 @@ services:
       interval: 5s
       timeout: 30s
       retries: 60
+
+  # Zipkin demo app, used only by the zipkin case. Reports Zipkin spans
+  # straight to OAP's receiver rather than through a SkyWalking agent.
+  zipkin-frontend:
+    image: "${SW_BRAVE_IMAGE}"
+    entrypoint: start-frontend
+    networks: [e2e]
+    expose: ["8081"]
+    environment:
+      ZIPKIN_BASEURL: http://oap:9411
+
+  zipkin-backend:
+    image: "${SW_BRAVE_IMAGE}"
+    entrypoint: start-backend
+    # The frontend calls its peer at the hardcoded hostname `backend`, so the
+    # descriptive service name needs an alias — otherwise the frontend answers
+    # 500 with an NXDOMAIN, and infra-e2e's trigger blocks forever waiting for
+    # a 2xx that will never come.
+    networks:
+      e2e:
+        aliases: [backend]
+    expose: ["9000"]
+    environment:
+      ZIPKIN_BASEURL: http://oap:9411
 
 networks:
   e2e:

--- a/test/e2e/script/env
+++ b/test/e2e/script/env
@@ -56,6 +56,16 @@ SW_E2E_SERVICE_COMMIT=95a296e2c810e6280b16975dd411e9c595a16836
 # predates this commit, so a tag here would be a downgrade.
 SW_CTL_COMMIT=85e5afdb3d55c6e5af66a472c3fe8ac024d11690
 
+# Zipkin demo app — openzipkin's own Brave example, used by the zipkin case.
+# A frontend calling a backend, both reporting Zipkin spans, which is what
+# exercises OAP's Zipkin receiver and Horizon's Zipkin query surface.
+SW_BRAVE_IMAGE=ghcr.io/openzipkin/brave-example:armeria
+
+# ElasticSearch, for the case that exercises Horizon's pre-v2 trace path.
+# Trace Query v2 is BanyanDB-only, so this is the ONLY deployment where
+# hasQueryTracesV2Support is false and the v1 branch runs at all.
+ES_VERSION=8.18.8
+
 # The browser runs INSIDE this image, in CI and on a laptop alike, so the e2e
 # environment is locked to one Ubuntu. Chromium's rendering, fonts and system
 # libraries are then identical everywhere, and a local run reproduces CI

--- a/test/e2e/script/prepare/horizon-post.sh
+++ b/test/e2e/script/prepare/horizon-post.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#     horizon-post.sh <base-url> <path> <json-body>
+#
+# Signs in and POSTs to an authenticated BFF route, printing the body on
+# stdout. The query-shaped routes (traces, logs, landing) take their
+# conditions in a body rather than the query string, so a verify case cannot
+# reach them with horizon-get.sh.
+
+set -eu
+
+BASE="${1:?usage: horizon-post.sh <base-url> <path> <json-body>}"
+PATH_="${2:?usage: horizon-post.sh <base-url> <path> <json-body>}"
+BODY="${3:-{\}}"
+
+USER="${HORIZON_E2E_USER:-e2e}"
+PASSWORD="${HORIZON_E2E_PASSWORD:-e2e-passw0rd}"
+
+JAR=$(mktemp)
+trap 'rm -f "${JAR}"' EXIT
+
+curl -sSf -c "${JAR}" -X POST "${BASE}/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"${USER}\",\"password\":\"${PASSWORD}\"}" > /dev/null
+
+curl -sSf -b "${JAR}" -X POST "${BASE}${PATH_}" \
+  -H 'Content-Type: application/json' \
+  -d "${BODY}"

--- a/test/e2e/script/prepare/install.sh
+++ b/test/e2e/script/prepare/install.sh
@@ -59,6 +59,15 @@ case "${NAME}" in
     # is pinned in script/env; re-install when the installed one does not
     # match, otherwise a stale swctl from another project silently wins.
     ctl_commit=$(grep -E '^SW_CTL_COMMIT=' "${here}/script/env" | head -1 | cut -d= -f2-)
+    # Check BIN_DIR before PATH: CI restores a cached binary straight into it,
+    # and that restore must count as "already installed" regardless of whether
+    # PATH has been exported yet. Building it takes about a minute, which is
+    # the single largest fixed cost in the case.
+    if [ -x "${BIN_DIR}/swctl" ] &&
+       "${BIN_DIR}/swctl" --version 2>/dev/null | grep -q "${ctl_commit:0:7}"; then
+      echo "swctl already at ${ctl_commit:0:7} (${BIN_DIR}/swctl)"
+      exit 0
+    fi
     if command -v swctl > /dev/null 2>&1 && swctl --version 2>/dev/null | grep -q "${ctl_commit:0:7}"; then
       echo "swctl already at ${ctl_commit:0:7}"
       exit 0


### PR DESCRIPTION
Four changes to the e2e suite, in the order they pay off.

## 1. Cache the swctl build

`skywalking-cli` publishes no binaries, so every run compiles it from source — **66 seconds, measured**, and the largest fixed cost in a case.

Now cached on the **pinned commit** rather than on the file that holds it, so bumping an unrelated image pin does not throw the compiler back at us. The installer checks the bin directory *before* `PATH`, because CI restores the cached binary straight into it and that restore has to count as "installed" whether or not the PATH export step has run yet.

Measured: cache hit **0.1s**, cache miss rebuilds at the correct pin (`swctl version 85e5afd…`). The first run after merge is a miss, so the saving shows from the second run on.

## 2. DSL management and the live debugger, from `core`

Costs **no containers at all**: `receiver-runtime-rule` and `dsl-debugging` are on by default in OAP, and `core` already exposes the admin host.

The assertion worth naming ties the fixture to the feature — `/api/catalog/bundled?catalog=lal` returns the very LAL rule `base-compose.yml` mounts, so the admin host is demonstrably reading the same configuration the log pipeline runs on, rather than the two being separately plausible.

All read-only. Pushing a rule would mutate the OAP every other case asserts against, and a half-applied hot-update would surface as an unrelated failure elsewhere in the run. Write coverage of the push flow belongs in a case that owns its stack.

## 3. `es` — ElasticSearch storage

Earns a deployment for exactly one reason: **Trace Query v2 is BanyanDB-only**, so this is the only configuration where `hasQueryTracesV2Support` comes back false and the v1 path runs. No amount of BanyanDB testing reaches that branch.

Deliberately **not** a copy of `core` — re-asserting every signal on a second backend would double the runtime to re-prove what storage does not affect.

One subtlety worth flagging for review: the backend assertion reads `other`, not `elasticsearch`. `backend` is a *capability classification* inferred from TTL shape, not a storage name, and the distinction it draws — BanyanDB capability set or not — is exactly the one that decides whether v2 is available. I initially wrote `elasticsearch` and the failing case corrected my understanding of the code.

## 4. `zipkin` — receiver and query surface

A different **receiver** and a different **query surface**: the demo app reports Zipkin spans straight to OAP rather than through a SkyWalking agent, and Horizon reads them over the Zipkin-compatible API instead of GraphQL.

Reachability is asserted **first**, because with the default localhost URL Horizon reports `zipkinReachable: false` and the whole surface stays dark — which reads as "no traces" rather than "wrong URL".

The Brave frontend calls its peer at the hardcoded hostname `backend`, so the descriptive service name carries a network alias. Without it the frontend answers 500 with an NXDOMAIN and infra-e2e's `trigger` blocks forever waiting for a 2xx — turning a fixture bug into a job that burns to its 45-minute timeout rather than failing.

## Validation

All three cases run end to end locally through the `e2e` CLI:

| case | verify cases |
| --- | --- |
| `core (BanyanDB)` | 7 |
| `es (ElasticSearch)` | 5 |
| `zipkin (receiver + query)` | 2 |

Plus licence headers and type-check. They run as parallel matrix entries, so wall clock stays near one case rather than their sum.

## Not in this PR

`browser` (needs a client-js app) and `deployment` (needs a BanyanDB **cluster** — liaison + data nodes) are still unbuilt. They are the two most fixture-heavy cases remaining and are tracked in the case matrix in `.github/workflows/e2e.yaml`.

Also noted in the README while it was fresh: write a case's `expected/` files **before** its first run — a missing expected file is retried for the entire budget and can never succeed, so a typo costs the full retry window instead of failing fast.