### PR TITLE
test(e2e): make the metric aggregation-mode spec fail without the fix

### DIFF
--- a/test/e2e/playwright/specs/admin/overview-metric-widget.spec.ts
+++ b/test/e2e/playwright/specs/admin/overview-metric-widget.spec.ts
@@ -28,17 +28,39 @@ test('the metric widget offers both aggregation modes', async ({ page, pageError
   await page.goto('/admin/overview-templates');
   await expect(page.locator('.ot')).toBeVisible({ timeout: 45_000 });
 
-  await page.locator('.ot__pv-grid .ot__cw').first().click();
-  const drawer = page.locator('.ot__drawer, .ot__editor-split').first();
-  await expect(drawer).toBeVisible({ timeout: 45_000 });
+  // ADD a metric widget rather than opening whichever cell happens to be
+  // first. The bundled dashboard leads with a kpi-tile, which always had the
+  // mode control — selecting it asserts nothing about `metric` and passes
+  // against the unfixed build, which is exactly what this spec exists to
+  // catch. `metric` is the composer's default type.
+  await page.locator('button.ot__add-trigger').click();
+  const composer = page.locator('.ot__composer');
+  await expect(composer).toBeVisible();
+  await expect(composer.locator('select').first()).toHaveValue('metric');
+  await composer.locator('button.ot__btn--primary').click();
 
-  // The mode radio was gated to kpi-tile / metric-composite, so a `metric`
-  // could never reach the page-side path even though the renderer supports
-  // it. Both options must be offered.
-  const modes = page.locator('.ot__agg-opt input[type="radio"]');
-  await expect
-    .poll(async () => modes.count(), { timeout: 45_000 })
-    .toBeGreaterThan(1);
+  // Open the one just created — it is appended, so it is last.
+  const cells = page.locator('.ot__pv-grid .ot__cw');
+  await expect(cells.last()).toBeVisible({ timeout: 45_000 });
+  await cells.last().click();
 
-  expect(pageErrors).toEqual([]);
+  // The editor panel carries a per-type modifier, so the assertion is scoped
+  // to a METRIC widget's own form rather than to whatever else is on screen.
+  const panel = page.locator('.ot__widget--metric');
+  await expect(panel, 'the drawer is not showing a metric widget').toBeVisible({
+    timeout: 45_000,
+  });
+
+  // Both modes must be offered here: server-side (the MQE self-aggregates)
+  // and page-side (fan out per service, then roll up). The control used to be
+  // withheld from this widget type even though the renderer honoured it.
+  const modes = panel.locator('.ot__agg-opt input[type="radio"]');
+  await expect.poll(async () => modes.count(), { timeout: 45_000 }).toBe(2);
+
+  // And the aggregation choice appears only in the mode that reads it.
+  await expect(panel.locator('select').filter({ hasText: 'avg' })).toHaveCount(0);
+  await modes.last().check();
+  await expect(panel.locator('select').filter({ hasText: 'avg' })).toHaveCount(1);
+
+  expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
 });

--- a/test/e2e/playwright/specs/fixture.ts
+++ b/test/e2e/playwright/specs/fixture.ts
@@ -78,13 +78,18 @@ export const MESH_LAYER = 'mesh';
 export const MESH_PEERS = ['productpage', 'reviews', 'details'];
 
 /**
- * Every service the MESH layer may resolve to, which is the peers PLUS the
- * ingress gateway — bookinfo is reached through it, so ALS reports it like
- * any other mesh workload. Which one the header lands on follows OAP's
- * ordering and changes between runs, so an assertion on the selected service
- * has to accept the whole set.
+ * EVERY service this fixture's mesh can produce: all four bookinfo workloads
+ * plus the ingress gateway bookinfo is reached through, which ALS reports
+ * like any other mesh workload.
+ *
+ * Distinct from MESH_PEERS on purpose. `ratings` is reached only via
+ * reviews-v2/v3, so whether it exists in a given window depends on which
+ * review version the traffic hit — it cannot be REQUIRED to be listed, but it
+ * can certainly be the one the header resolves to. Which service that is
+ * follows OAP's ordering and changes between runs, so anything asserting on
+ * the SELECTED service must accept the full set.
  */
-export const MESH_SERVICES = [...MESH_PEERS, 'istio-ingressgateway'];
+export const MESH_SERVICES = [...MESH_PEERS, 'ratings', 'istio-ingressgateway'];
 
 /**
  * The SAME workload in the MESH_DP layer, which names services


### PR DESCRIPTION
Follow-up to #113, addressing [this review comment](https://github.com/apache/skywalking-horizon-ui/pull/113#discussion_r3722445221).

## The problem

The aggregation-mode spec opened whichever widget came **first** on the bundled Services Dashboard — a `kpi-tile`, which has always carried the mode control — and then asserted the radios existed. So it asserted nothing about `metric`, and passed against a build where the control was still withheld from that type.

That is not hypothetical: it passed in the #113 runs *before* the e2e image was rebuilt, i.e. against the unfixed UI. I read that as reassurance at the time. A guard that passes without the fix guards nothing.

## The fix

- **adds** a metric widget through the composer (asserting `metric` really is the default type) instead of opening whatever is first
- scopes the assertions to `.ot__widget--metric`, the drawer's per-type modifier, with a failure message that says the drawer is not showing a metric
- requires **exactly two** mode radios in that panel
- covers the other half of #113 that nothing asserted: the **Aggregation** select is absent in server-side mode, where it is never read, and appears once page-side is chosen

## Verified in both directions

| build | result |
| --- | --- |
| pre-fix drawer (`a6cb441~1`), image rebuilt from it | **9 passed / 1 failed** — `Expected: 2, Received: 0` (no mode radios on a metric widget) |
| current `main` | **10 passed / 0 failed** |

The negative control is the point of this PR: the previous spec passed in both directions.
