### PR TITLE
test(e2e): live debug that CAPTURES — LAL and OAL on core, MAL on deployment

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,11 @@
 #             alarms and their timeline, trace profiling (task create ->
 #             list), the trace DETAIL — duration scatter, waterfall, tree,
 #             statistics and the span modal — the services overview
-#             dashboard, shell and login
+#             dashboard, shell and login, plus two live debug CAPTURES:
+#             LAL live debug over logs driven while the session is open, and
+#             OAL live debug entered the way an operator reaches it — the
+#             catalog's green ▶ on the `service_cpm` statement — through to
+#             a captured Service source row carrying a fixture service name
 #             components: LayerWidgetTile, TimeChart, TopList, RecordList,
 #             TraceListPanel, LayerTracesView, TracePopout, LogStreamPanel,
 #             LogDetailPopout, LayerServiceMapView, TopologyDetailPanels,
@@ -61,7 +65,9 @@
 #             TraceDistribution, TraceDetailCard, TraceWaterfallView,
 #             TraceTreeView, TraceStatsView, SpanDetailModal,
 #             OverviewDashboardView, KpiTileWidget, MetricCompositeWidget,
-#             AlarmsWidget, SectionBreak, AppShell
+#             AlarmsWidget, SectionBreak, AppShell, DebugView,
+#             DebugLal (LAL live debug), OalCatalogView + DebugOal (OAL
+#             live debug)
 #
 #   es        the same, storing to ElasticSearch instead        ACTIVE
 #             tests: the trace page on a non-BanyanDB backend — query-API
@@ -80,18 +86,24 @@
 #             case's own state. The admin pages themselves are covered only
 #             as far as MOUNTING and listing; editing and pushing from the
 #             page are not exercised
-#             components: DslCatalogView, DebugHistoryView, LiveDebuggerView,
-#             OverviewTemplatesAdmin, LayerDashboardsAdmin — mount + list
+#             components: DslCatalogView, DebugHistoryView,
+#             LiveDebuggerView (the live debug page itself — no capture is
+#             started here; the MAL / LAL / OAL runs live in `deployment`
+#             and `core`), OverviewTemplatesAdmin, LayerDashboardsAdmin
+#             — mount + list
 #
 #   deployment  BanyanDB as a CLUSTER on kind, via its helm chart  ACTIVE
 #             with FODC, plus an OTel collector
 #             tests: the BANYANDB layer — the cluster resolving from the
 #             collector's `cluster` label, the `table` widget form (declared
-#             by no template any other case reaches), and the Deployment tab
-#             drawing the cluster grouped by node role
-#             components: TableWidget, LayerDeploymentView (its edge panel
-#             and metric rows; the edge Sparkline itself is NOT asserted —
-#             the series is still sparse on a minutes-old cluster)
+#             by no template any other case reaches), the Deployment tab
+#             drawing the cluster grouped by node role, and a MAL live debug
+#             CAPTURE — the collector feeds `otel-rules/banyandb`, the only
+#             MAL rule any case's fixture reaches
+#             components: TableWidget, DebugMal (MAL live debug),
+#             LayerDeploymentView (its edge panel and metric rows; the
+#             edge Sparkline itself is NOT asserted — the series is still
+#             sparse on a minutes-old cluster)
 #
 #   istio     kind + Istio + rover, in place of compose         ACTIVE
 #             tests: the MESH layer — service list, mesh topology, and the

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -21,12 +21,18 @@
 #     make images          build the images compose expects (never pulled)
 #     make run CASE=core   full infra-e2e cycle for one case
 #     make run-istio-without-profiling   the mesh case minus rover (macOS)
-#     make setup CASE=core bring the stack up and leave it up
-#     make cleanup CASE=core
+#     make dev CASE=core   bring the stack up and LEAVE it up (see below)
+#     make dev-down CASE=core
 
 E2E ?= e2e
 CASE ?= core
-CASE_FILE = cases/$(CASE)/e2e.yaml
+# A case's commands run with infra-e2e's own working directory, and the cases
+# spell every script from the REPO ROOT (`bash test/e2e/script/...`) because
+# that is where CI invokes the CLI. So a case runs from there too — started
+# from `test/e2e` it dies on its first step, with a `No such file or
+# directory` that reads like a missing script rather than a wrong directory.
+ROOT = $(CURDIR)/..
+CASE_FILE = test/e2e/cases/$(CASE)/e2e.yaml
 
 .PHONY: images
 images:
@@ -40,14 +46,14 @@ images-demo:
 
 .PHONY: run
 run:
-	$(E2E) run -c $(CASE_FILE)
+	cd $(ROOT) && $(E2E) run -c $(CASE_FILE)
 
 # The istio case with profiling switched off, for machines with no Linux
 # kernel for eBPF probes to attach to. Same case file, same fixture — the flag
 # drops the rover deployment and the verification that depends on it.
 .PHONY: run-istio-without-profiling
 run-istio-without-profiling:
-	E2E_SKIP_PROFILING=true $(E2E) run -c cases/istio/e2e.yaml
+	cd $(ROOT) && E2E_SKIP_PROFILING=true $(E2E) run -c test/e2e/cases/istio/e2e.yaml
 
 # Spec iteration: a stack that OUTLIVES the command that started it.
 #

--- a/test/e2e/playwright/specs/deployment/mal-debug.spec.ts
+++ b/test/e2e/playwright/specs/deployment/mal-debug.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../support/diagnostics.js';
+
+// A live MAL debug RUN.
+//
+// MAL samples whichever rule you select, and the debugger lists `otel-rules`,
+// `log-mal-rules` and `telegraf-rules`. This is the only case that feeds any
+// of them: its OTel collector scrapes the FODC proxy into `otel-rules/banyandb`,
+// so a capture here has records to catch. `core` has logs and traces but
+// nothing that reaches a rule the debugger offers, which is why the LAL run
+// lives there and this one does not.
+//
+// The rule is chosen BY NAME. Picking the first option lands on whatever
+// sorts first — `log-mal-rules · miniprogram-alipay` in practice — a rule no
+// fixture feeds, so the capture waits forever on data that cannot arrive.
+//
+// Starting a session mutates OAP, which this case already owns.
+
+/** Pick a rule file by NAME + its first rule, then start. Both selects gate
+ *  the button. */
+async function startSampling(page: Page, filePattern: RegExp): Promise<void> {
+  const file = page.locator('select.ctl__select').first();
+  await expect(file).toBeVisible({ timeout: 45_000 });
+  await expect
+    .poll(async () => file.locator('option').count(), { timeout: 60_000 })
+    .toBeGreaterThan(1);
+  const label = (await file.locator('option').allTextContents()).find((o) => filePattern.test(o));
+  expect(label, `no rule file matching ${filePattern} — the debugger lists none this fixture feeds`).toBeTruthy();
+  await file.selectOption({ label: label! });
+
+  const rule = page.locator('select.ctl__select').nth(1);
+  await expect
+    .poll(async () => rule.locator('option').count(), { timeout: 60_000 })
+    .toBeGreaterThan(1);
+  await rule.selectOption({ index: 1 });
+
+  const start = page.getByRole('button', { name: 'start sampling' });
+  await expect(start, 'sampling stayed disabled after picking a file and rule').toBeEnabled({
+    timeout: 45_000,
+  });
+  await start.click();
+  await expect(page.getByRole('button', { name: 'stop' })).toBeEnabled({ timeout: 45_000 });
+}
+
+test('the MAL debugger samples the collector metrics', async ({ page, pageErrors }) => {
+  test.setTimeout(300_000);
+  await page.goto('/operate/live-debug/mal');
+  await startSampling(page, /banyandb/);
+
+  // `.mal__empty` renders in the records' place when a capture catches
+  // nothing, so asserting the page or the session state would pass on a
+  // debugger that samples and shows nothing.
+  await expect(page.locator('.mal__records').first()).toBeVisible({ timeout: 240_000 });
+
+  expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
+});

--- a/test/e2e/playwright/specs/ui/dsl-debug.spec.ts
+++ b/test/e2e/playwright/specs/ui/dsl-debug.spec.ts
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../support/diagnostics.js';
+
+// Live debug RUNS, not just the pages.
+//
+// The debugger's job is to sample real records through a rule and show what
+// each statement did with them. The suite already proved the page mounts and
+// that a session starts ON THE WIRE — neither says the matrix ever renders a
+// record.
+//
+// LAL samples the service's shipped LOGS. The fixture emits those as a
+// one-off burst during setup, so a capture started later sees nothing
+// (`ok 0 bytes · no LAL records from this node`) — the test has to drive
+// traffic while the session is live.
+//
+// MAL is NOT here. It samples whichever rule you select, and the debugger
+// lists only `otel-rules`, `log-mal-rules` and `telegraf-rules` — the agent's
+// own meter stream is analysed by meter-analyzer-config, which is not one of
+// those catalogs. Nothing this fixture emits reaches a rule it offers, so MAL
+// belongs in `deployment`, where an OTel collector feeds `otel-rules/banyandb`.
+//
+// OAL is here, and it enters from the CATALOG page rather than the debugger's
+// own controls. The OAL tab has no rule list to pick from — the metric is a
+// free-text box, because a metric is any LHS in any loaded `.oal` file — so
+// the operator's path is `/operate/oal`: pick the file, find the statement,
+// hit the green ▶ in its gutter, which deep-links into the debugger with the
+// picker filled in. `service_cpm` samples `Service.*`, which the fixture's
+// continuous `/users` traffic dispatches every few seconds.
+//
+// Starting a session mutates OAP — the same scoped write the trace-profiling
+// spec makes.
+
+/** Pick a rule file + rule, then start. Both selects gate the button. */
+async function startSampling(page: Page, filePattern: RegExp): Promise<void> {
+  const file = page.locator('select.ctl__select').first();
+  await expect(file).toBeVisible({ timeout: 45_000 });
+  await expect
+    .poll(async () => file.locator('option').count(), { timeout: 60_000 })
+    .toBeGreaterThan(1);
+  const label = (await file.locator('option').allTextContents()).find((o) => filePattern.test(o));
+  expect(label, `no rule file matching ${filePattern}`).toBeTruthy();
+  await file.selectOption({ label: label! });
+
+  const rule = page.locator('select.ctl__select').nth(1);
+  await expect
+    .poll(async () => rule.locator('option').count(), { timeout: 60_000 })
+    .toBeGreaterThan(1);
+  await rule.selectOption({ index: 1 });
+
+  const start = page.getByRole('button', { name: 'start sampling' });
+  await expect(start, 'sampling stayed disabled after picking a file and rule').toBeEnabled({
+    timeout: 45_000,
+  });
+  await start.click();
+  await expect(page.getByRole('button', { name: 'stop' })).toBeEnabled({ timeout: 45_000 });
+}
+
+test('the LAL debugger samples logs driven while it is live', async ({ page, pageErrors }) => {
+  test.setTimeout(300_000);
+  await page.goto('/operate/live-debug/lal');
+  await startSampling(page, /horizon-e2e/);
+
+  // Logs only exist while something emits them. The demo provider is on the
+  // same compose network as this browser, so the page can drive its
+  // log-emitting endpoint from inside the session — which is also the honest
+  // shape of the test: records must flow THROUGH the rule while sampling.
+  const drive = page.evaluate(async () => {
+    for (let i = 0; i < 40; i += 1) {
+      try {
+        await fetch('http://provider:9090/logs/trigger', { mode: 'no-cors' });
+      } catch {
+        /* the page is cross-origin to the provider; the request still lands */
+      }
+      await new Promise((r) => setTimeout(r, 1_500));
+    }
+  });
+
+  await expect(page.locator('.lal__matrixblock').first()).toBeVisible({ timeout: 240_000 });
+  await drive.catch(() => undefined);
+
+  // The panel's search filters the captured records by their CONTENT — the
+  // log body and the builder's output tags — which is how an operator finds
+  // the one record they care about in a busy capture. A nonsense needle must
+  // empty the matrix, and clearing it must bring the records back; asserting
+  // only the first half would pass on a search that broke the view outright.
+  // Filtering narrows the records WITHIN the matrix; the block itself stays,
+  // and a needle that matches nothing surfaces `.lal__nomatch` — which is a
+  // different message from "no records on this node", so it also proves the
+  // empty state knows why it is empty.
+  const search = page.locator('input.lal__searchinput');
+  await expect(search).toBeVisible();
+  await search.fill('zzz-no-such-log-zzz');
+  await expect(page.locator('.lal__nomatch').first()).toBeVisible({ timeout: 45_000 });
+
+  // Clearing brings them back — asserting only the empty half would pass on a
+  // search that broke the view outright.
+  await search.fill('');
+  await expect(page.locator('.lal__matrixblock').first()).toBeVisible({ timeout: 45_000 });
+
+  expect(pageErrors).toEqual([]);
+});
+
+test('the OAL catalog runs the statement its green arrow points at', async ({
+  page,
+  pageErrors,
+}) => {
+  test.setTimeout(300_000);
+  await page.goto('/operate/oal');
+
+  // Pick the file BY NAME. The catalog auto-selects the first one, which is
+  // whichever OALDefine the OAP build happens to load first — clicking a
+  // position instead would follow that order rather than this test's intent.
+  const coreFile = page.locator('button.oal__fileitem', { hasText: 'core.oal' });
+  await expect(coreFile).toBeVisible({ timeout: 60_000 });
+  await coreFile.click();
+  // OAP names a file by its classpath entry (`oal/core.oal` today, bare
+  // `core.oal` on older builds), so the name is READ off the list rather
+  // than spelled here — the picker has to receive whatever OAP reported.
+  const fileName = ((await coreFile.textContent()) ?? '').trim();
+
+  // Lock onto the statement by its CONTENT. `core.oal` is upstream's file and
+  // its line numbers move whenever a metric is added above this one, so a
+  // gutter position — or an nth() — would break on an OAP bump that changed
+  // nothing about the feature. There is no search box on this page to narrow
+  // with; the statement text is the only stable handle.
+  const statement = page.locator('.oal__line--debuggable', {
+    hasText: /service_cpm\s*=\s*from\(/,
+  });
+  await expect(statement, 'core.oal no longer declares service_cpm').toHaveCount(1);
+  await statement.locator('button.oal__dbgbtn').click();
+
+  // The ▶ is a deep link, and the picker it fills is the whole contract
+  // between the two pages: the debugger has no rule list, so a jump that
+  // landed with an empty metric box would leave the operator retyping it.
+  await expect(page).toHaveURL(/\/operate\/live-debug\/oal\?/);
+  await expect(page.locator('select.ctl__select')).toHaveValue(fileName);
+  await expect(page.locator('input.ctl__input--flex')).toHaveValue('service_cpm');
+
+  const start = page.getByRole('button', { name: 'start sampling' });
+  await expect(start, 'the deep-linked picker left sampling disabled').toBeEnabled({
+    timeout: 45_000,
+  });
+  await start.click();
+  await expect(page.getByRole('button', { name: 'stop' })).toBeEnabled({ timeout: 45_000 });
+
+  // The capture is keyed to the metric the arrow named — `.oal__empty` renders
+  // in the groups' place when a session catches nothing, so asserting the node
+  // or the session state would pass on a debugger that samples and shows
+  // nothing.
+  await expect(page.locator('code.oal__rulename').first()).toHaveText('service_cpm', {
+    timeout: 240_000,
+  });
+
+  // …and the row it captured is the fixture's own traffic. The payload is the
+  // assertion: a waterfall that renders its steps with empty payloads looks
+  // identical to a working one until you read a value out of it. Matched
+  // against the service SET — which of the two dispatches first is traffic
+  // timing, not correctness.
+  await expect(
+    page.locator('.oal__kvline').filter({ hasText: /e2e-service-(provider|consumer)/ }).first(),
+    'no captured source row carried a fixture service name',
+  ).toBeVisible({ timeout: 240_000 });
+
+  expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
+});


### PR DESCRIPTION
## Why

The suite proved the live debugger mounts, and that a session starts on the wire. Neither says a record ever reaches the screen — which is the only thing the feature exists to do. A debugger that installs a session and then renders an empty node looks identical to a working one until you read a captured value out of it.

## What

**LAL, on `core`.** The fixture emits its logs as a one-off burst during setup, so a capture started afterwards sees nothing. The spec drives the provider's log endpoint from inside the page while the session is live — records flow THROUGH the rule while it samples — then filters the matrix by content and clears the filter again, so a search that empties the view outright cannot pass.

**MAL, on `deployment`.** The debugger lists only `otel-rules`, `log-mal-rules` and `telegraf-rules`, and the one fixture that feeds any of them is the OTel collector beside the BanyanDB cluster. The rule file is picked by NAME, not by index: option 0 is `log-mal-rules · miniprogram-alipay`, which nothing feeds.

**OAL, on `core`, entered from the catalog.** The OAL tab has no rule list — a metric is any LHS in any loaded `.oal` file, so the control is free text — which makes the catalog the operator's real entry point. The spec takes that path: pick the file by name, find the `service_cpm` statement by its CONTENT (`core.oal` is upstream's file and its line numbers move whenever a metric is added above it), click the green ▶ in its gutter, and assert the deep link filled the picker. Then it asserts the capture came back keyed to that metric, and that a captured `Service` source row carries a fixture service name — matched against the provider/consumer SET, since which one dispatches first is traffic timing.

The file name is READ off the catalog row rather than spelled in the spec: OAP names a file by its classpath entry, `oal/core.oal` today, and the picker has to receive whatever OAP reported.

The case table in `.github/workflows/e2e.yaml` records all three, naming the capability rather than the component — `DebugLal (LAL live debug)`, `DebugMal (MAL live debug)`, `OalCatalogView + DebugOal (OAL live debug)` — and `admin`'s entry now says its `LiveDebuggerView` coverage starts no capture, so the entry a case echoes before it boots distinguishes the two.

**`make -C test/e2e run CASE=<case>` never worked.** It ran the CLI from `test/e2e` while every case spells its scripts from the repo root, so a case died on its first step with a `No such file or directory` that reads like a missing script rather than a wrong directory (exit 127 from `test/e2e`, exit 0 from the root). The targets run from the root now, and the header advertises the `dev*` targets that exist instead of `setup` / `cleanup`, which do not.

## Validation

Both cases were run locally against real fixtures, not just type-checked.

`core` — driven the way `playwright.sh` does it, browser inside the fixture network (pinned `mcr.microsoft.com/playwright:v1.62.1-noble`, `HORIZON_BASE_URL=http://horizon:8081`): **3 passed** (auth, LAL capture, OAL capture). Run from the host instead, the LAL spec fails on `provider:9090` — the browser has to be on the compose network, which is why the harness puts it there.

`deployment` — full `e2e run -c test/e2e/cases/deployment/e2e.yaml` on kind: **4 passed, 0 failed**, including `playwright.sh deployment`.

The OAL assertions were also checked against a second, independent OAP (the public demo, `11.0.0-SNAPSHOT`): same catalog → ▶ → picker → capture path, with the waterfall walking `input → function → aggregation → output`.

Preflight: `pnpm -r run type-check`, both app builds, `pnpm license:check` (0 invalid), `pnpm -r run lint`, `pnpm -r run test:unit` (753 bff + 440 ui) all green. No changelog or `docs/` entry — the change is test and tooling only.