### PR TITLE
feat(ui): add six Node.js runtime dashboard panels (6 -> 12)

### DIFF
--- a/apps/bff/src/bundled_templates/layers/general.i18n.de.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.de.json
@@ -178,6 +178,48 @@
         ]
       },
       {
+        "title": "Array-Puffer",
+        "tip": "Node.js-Agent: ArrayBuffer-/SharedArrayBuffer-Speicher in MB (process.memoryUsage().arrayBuffers).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Prozesslaufzeit",
+        "tip": "Node.js-Agent: Tage seit Prozessstart (process.uptime()).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Spitzen-malloc-Speicher",
+        "tip": "Node.js-Agent: Maximaler V8-malloc-Speicher in MB (v8.getHeapStatistics().peak_malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Malloc-Speicher",
+        "tip": "Node.js-Agent: aktueller V8-malloced-Speicher in MB (v8.getHeapStatistics().malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "V8-Old-Space genutzt",
+        "tip": "Node.js-Agent: genutzter V8-Old-Space in MB (v8.getHeapSpaceStatistics old_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "V8-New-Space genutzt",
+        "tip": "Node.js-Agent: genutzter V8-New-Space in MB (v8.getHeapSpaceStatistics new_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "JVM-CPU",
         "tip": "JVM-CPU, gemeldet vom Agenten. Wird nur angezeigt, wenn die Instanz eine JVM ist.",
         "expressions": [

--- a/apps/bff/src/bundled_templates/layers/general.i18n.es.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.es.json
@@ -137,6 +137,48 @@
         ]
       },
       {
+        "title": "Búferes de array",
+        "tip": "Agente Node.js: memoria ArrayBuffer/SharedArrayBuffer en MB (process.memoryUsage().arrayBuffers).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Tiempo activo del proceso",
+        "tip": "Agente Node.js: días desde el inicio del proceso (process.uptime()).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Memoria malloc máxima",
+        "tip": "Agente Node.js: memoria malloc máxima de V8 en MB (v8.getHeapStatistics().peak_malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Memoria malloc actual",
+        "tip": "Agente Node.js: memoria malloc actual de V8 en MB (v8.getHeapStatistics().malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Generación antigua usada",
+        "tip": "Agente Node.js: heap V8 de generación antigua usado en MB (v8.getHeapSpaceStatistics old_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Generación nueva usada",
+        "tip": "Agente Node.js: heap V8 de generación nueva usado en MB (v8.getHeapSpaceStatistics new_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "CPU JVM",
         "tip": "CPU JVM según reporta el agente. Solo se muestra cuando la instancia es una JVM."
       },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.fr.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.fr.json
@@ -120,6 +120,48 @@
         ]
       },
       {
+        "title": "Tampons de tableau",
+        "tip": "Agent Node.js : mémoire ArrayBuffer/SharedArrayBuffer en MB (process.memoryUsage().arrayBuffers).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Durée de fonctionnement du processus",
+        "tip": "Agent Node.js : jours depuis le démarrage du processus (process.uptime()).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Mémoire malloc de pic",
+        "tip": "Agent Node.js : mémoire malloc V8 de pic en MB (v8.getHeapStatistics().peak_malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Mémoire malloc actuelle",
+        "tip": "Agent Node.js : mémoire malloc V8 actuelle en MB (v8.getHeapStatistics().malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Ancienne génération utilisée",
+        "tip": "Agent Node.js : heap V8 de l'ancienne génération utilisé en MB (v8.getHeapSpaceStatistics old_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Nouvelle génération utilisée",
+        "tip": "Agent Node.js : heap V8 de la nouvelle génération utilisé en MB (v8.getHeapSpaceStatistics new_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "CPU JVM",
         "tip": "CPU JVM tel que remonté par l'agent. Ne s'affiche que lorsque l'instance est une JVM."
       },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.ja.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.ja.json
@@ -120,6 +120,48 @@
         ]
       },
       {
+        "title": "配列バッファ",
+        "tip": "Node.js エージェント：ArrayBuffer / SharedArrayBuffer メモリ（process.memoryUsage().arrayBuffers）、MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "プロセス稼働時間",
+        "tip": "Node.js エージェント：プロセス起動からの日数（process.uptime()）。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "ピーク malloc メモリ",
+        "tip": "Node.js エージェント：V8 ピーク malloc メモリ（v8.getHeapStatistics().peak_malloced_memory）、MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Malloc メモリ",
+        "tip": "Node.js エージェント：現在の V8 malloc メモリ（v8.getHeapStatistics().malloced_memory）、MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "旧世代ヒープ使用量",
+        "tip": "Node.js エージェント：V8 旧世代ヒープ使用量（v8.getHeapSpaceStatistics old_space）、MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "新世代ヒープ使用量",
+        "tip": "Node.js エージェント：V8 新世代ヒープ使用量（v8.getHeapSpaceStatistics new_space）、MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "JVM CPU",
         "tip": "エージェントが報告する JVM CPU。インスタンスが JVM の場合のみ描画。"
       },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.ko.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.ko.json
@@ -120,6 +120,48 @@
         ]
       },
       {
+        "title": "배열 버퍼",
+        "tip": "Node.js 에이전트: ArrayBuffer/SharedArrayBuffer 메모리(process.memoryUsage().arrayBuffers), MB.",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "프로세스 가동 시간",
+        "tip": "Node.js 에이전트: 프로세스 시작 이후 일수(process.uptime()).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "최대 malloc 메모리",
+        "tip": "Node.js 에이전트: V8 최대 malloc 메모리(v8.getHeapStatistics().peak_malloced_memory), MB.",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Malloc 메모리",
+        "tip": "Node.js 에이전트: 현재 V8 malloc 메모리(v8.getHeapStatistics().malloced_memory), MB.",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "구 세대 힙 사용량",
+        "tip": "Node.js 에이전트: V8 구 세대 힙 사용량(v8.getHeapSpaceStatistics old_space), MB.",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "신 세대 힙 사용량",
+        "tip": "Node.js 에이전트: V8 신 세대 힙 사용량(v8.getHeapSpaceStatistics new_space), MB.",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "JVM CPU",
         "tip": "에이전트가 보고하는 JVM CPU입니다. 인스턴스가 JVM일 때만 표시됩니다."
       },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.pt.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.pt.json
@@ -126,6 +126,48 @@
         ]
       },
       {
+        "title": "Buffers de matriz",
+        "tip": "Agente Node.js: memória ArrayBuffer/SharedArrayBuffer em MB (process.memoryUsage().arrayBuffers).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Tempo ativo do processo",
+        "tip": "Agente Node.js: dias desde o início do processo (process.uptime()).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Memória malloc de pico",
+        "tip": "Agente Node.js: memória malloc de pico do V8 em MB (v8.getHeapStatistics().peak_malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Memória malloc atual",
+        "tip": "Agente Node.js: memória malloc atual do V8 em MB (v8.getHeapStatistics().malloced_memory).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Geração antiga usada",
+        "tip": "Agente Node.js: heap V8 de geração antiga usado em MB (v8.getHeapSpaceStatistics old_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "Geração nova usada",
+        "tip": "Agente Node.js: heap V8 de geração nova usado em MB (v8.getHeapSpaceStatistics new_space).",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "CPU da JVM",
         "tip": "CPU da JVM conforme reportado pelo agente. Só aparece quando a instância é uma JVM."
       },

--- a/apps/bff/src/bundled_templates/layers/general.i18n.zh-CN.json
+++ b/apps/bff/src/bundled_templates/layers/general.i18n.zh-CN.json
@@ -91,6 +91,48 @@
         ]
       },
       {
+        "title": "数组缓冲区",
+        "tip": "Node.js agent：ArrayBuffer / SharedArrayBuffer 内存（process.memoryUsage().arrayBuffers），单位 MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "进程运行时间",
+        "tip": "Node.js agent：进程启动至今的天数（process.uptime()）。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "峰值 malloc 内存",
+        "tip": "Node.js agent：V8 峰值 malloc 内存（v8.getHeapStatistics().peak_malloced_memory），单位 MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "malloc 内存",
+        "tip": "Node.js agent：V8 当前 malloc 内存（v8.getHeapStatistics().malloced_memory），单位 MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "老生代已用",
+        "tip": "Node.js agent：V8 老生代堆已用（v8.getHeapSpaceStatistics old_space），单位 MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
+        "title": "新生代已用",
+        "tip": "Node.js agent：V8 新生代堆已用（v8.getHeapSpaceStatistics new_space），单位 MB。",
+        "expressions": [
+          null
+        ]
+      },
+      {
         "title": "JVM CPU",
         "tip": "由 agent 上报的 JVM CPU。仅当实例为 JVM 时显示。"
       },

--- a/apps/bff/src/bundled_templates/layers/general.json
+++ b/apps/bff/src/bundled_templates/layers/general.json
@@ -254,6 +254,72 @@
         "rowSpan": 2
       },
       {
+        "id": "nodejs_array_buffers",
+        "title": "Array Buffers",
+        "tip": "Node.js agent: ArrayBuffer / SharedArrayBuffer memory in MB (process.memoryUsage().arrayBuffers).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_nodejs_array_buffers/1048576"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_array_buffers", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "nodejs_uptime",
+        "title": "Process Uptime",
+        "tip": "Days since the process started (process.uptime()).",
+        "type": "line",
+        "unit": "days",
+        "expressions": ["meter_instance_nodejs_uptime/86400"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_uptime", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "nodejs_peak_malloced_memory",
+        "title": "Peak Malloced Memory",
+        "tip": "Node.js agent: peak V8 malloced memory in MB (v8.getHeapStatistics().peak_malloced_memory).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_nodejs_peak_malloced_memory/1048576"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_peak_malloced_memory", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "nodejs_malloced_memory",
+        "title": "Malloced Memory",
+        "tip": "Node.js agent: current V8 malloced memory in MB (v8.getHeapStatistics().malloced_memory).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_nodejs_malloced_memory/1048576"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_malloced_memory", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "nodejs_old_space_used",
+        "title": "Old Space Used",
+        "tip": "Node.js agent: V8 old generation heap used in MB (v8.getHeapSpaceStatistics old_space).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_nodejs_old_space_used/1048576"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_old_space_used", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
+        "id": "nodejs_new_space_used",
+        "title": "New Space Used",
+        "tip": "Node.js agent: V8 new generation heap used in MB (v8.getHeapSpaceStatistics new_space).",
+        "type": "line",
+        "unit": "MB",
+        "expressions": ["meter_instance_nodejs_new_space_used/1048576"],
+        "visibleWhen": { "kind": "mqe", "expression": "meter_instance_nodejs_new_space_used", "op": "exists" },
+        "span": 3,
+        "rowSpan": 2
+      },
+      {
         "id": "jvm_cpu",
         "title": "JVM CPU",
         "tip": "JVM CPU as reported by the agent. Renders only when the instance is a JVM.",

--- a/apps/bff/src/bundled_templates/layers/general.json
+++ b/apps/bff/src/bundled_templates/layers/general.json
@@ -267,7 +267,7 @@
       {
         "id": "nodejs_uptime",
         "title": "Process Uptime",
-        "tip": "Days since the process started (process.uptime()).",
+        "tip": "Node.js agent: days since the process started (process.uptime()).",
         "type": "line",
         "unit": "days",
         "expressions": ["meter_instance_nodejs_uptime/86400"],

--- a/docs/changelog/1.0.0.md
+++ b/docs/changelog/1.0.0.md
@@ -138,7 +138,7 @@
 
 ### General Service — Node.js runtime
 
-- **Six instance dashboard line widgets for Node.js runtime metrics** — process CPU, V8 heap used/total/limit, RSS, and external memory (`meter_instance_nodejs_*`). Each line widget uses `visibleWhen` so widgets render only when the Node.js agent reports runtime data.
+- **Twelve instance dashboard line widgets for Node.js runtime metrics** — process CPU, V8 heap used/total/limit, RSS, external memory, array buffers, process uptime, peak/current malloced memory, and V8 old/new space used (`meter_instance_nodejs_*`). Each line widget uses `visibleWhen` so widgets render only when the Node.js agent reports runtime data.
 
 ### General Service — metric-to-trace drill-down
 

--- a/docs/dashboards/general.md
+++ b/docs/dashboards/general.md
@@ -105,6 +105,10 @@ For one selected service instance. The first three widgets always render; the re
 - **V8 Heap Used** / **V8 Heap Total** / **V8 Heap Limit** — the V8 heap in MB: currently used, currently allocated, and the maximum the heap may grow to (`meter_instance_nodejs_heap_used` / `_heap_total` / `_heap_limit`).
 - **Process RSS** — resident set size in MB (`meter_instance_nodejs_rss`).
 - **External Memory** — memory held outside the V8 heap (buffers and native objects) in MB (`meter_instance_nodejs_external_memory`).
+- **Array Buffers** — ArrayBuffer / SharedArrayBuffer memory in MB (`meter_instance_nodejs_array_buffers`).
+- **Process Uptime** — days since the process started (`meter_instance_nodejs_uptime/86400`).
+- **Peak Malloced Memory** / **Malloced Memory** — peak and current V8 malloced memory in MB (`meter_instance_nodejs_peak_malloced_memory` / `_malloced_memory`).
+- **Old Space Used** / **New Space Used** — V8 old / new generation heap used in MB (`meter_instance_nodejs_old_space_used` / `_new_space_used`).
 
 **PHP (PHM) instances**
 


### PR DESCRIPTION
### Summary

Add **six more** General-layer **Instance** dashboard widgets for Node.js runtime meters (6 → **12**), aligned with OAP `meter_instance_nodejs_*` and agent [apache/skywalking-nodejs#143](https://github.com/apache/skywalking-nodejs/pull/143).

### Changes

- Add 6 line widgets in `general.json` (after the existing six):
  Array Buffers, Process Uptime, Peak Malloced Memory, Malloced Memory, Old Space Used, New Space Used
- Each widget uses MQE `visibleWhen` (`exists`) so panels appear only when the corresponding meter is present
- i18n overlays: `de` / `es` / `fr` / `ja` / `ko` / `pt` / `zh-CN`
- Changelog: `docs/changelog/1.0.0.md` (per-version file; root `CHANGELOG.md` was removed in #107)

### Related PRs

| Component | PR | Status |
|-----------|----|--------|
| Node.js agent | https://github.com/apache/skywalking-nodejs/pull/143 | **merged** |
| OAP | https://github.com/apache/skywalking/pull/13970 | companion |
| Prior UI (first 6 widgets) | https://github.com/apache/skywalking-horizon-ui/pull/87 | merged |

### CI (fork validation)

Fork CI only: https://github.com/songzhendong/skywalking-horizon-ui/pull/3

| Workflow | Result | Run |
|----------|--------|-----|
| **CI** | ✅ | https://github.com/songzhendong/skywalking-horizon-ui/actions/runs/31184729181 |
| **E2E** | ✅ | https://github.com/songzhendong/skywalking-horizon-ui/actions/runs/31184728533 |

### Notes

- Widgets appear under **General → Instances → &lt;instance&gt;** when a Node.js agent reports runtime meters.
- English tip wording on the **legacy** `nodejs_process_cpu` widget (*collect interval*) is pre-existing from #87; this PR does not change that tip. New widgets use report-interval wording.
