### PR TITLE
test(e2e): make the tightened assertions prove what their comments claim

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:bff": "pnpm --filter @skywalking-horizon-ui/bff dev",
     "build": "pnpm -r run build",
     "type-check": "pnpm -r run type-check",
-    "lint": "pnpm -r run lint && node scripts/check-source-budget.mjs && node scripts/check-ui-i18n.mjs && node scripts/check-ui-promises.mjs && node scripts/check-unused-deps.mjs && node scripts/check-security.mjs && node scripts/check-security-selftest.mjs && pnpm --filter @skywalking-horizon-ui/bff run i18n:validate && pnpm --filter @skywalking-horizon-ui/bff run templates:validate",
+    "lint": "pnpm -r run lint && node scripts/check-source-budget.mjs && node scripts/check-ui-i18n.mjs && node scripts/check-ui-promises.mjs && node scripts/check-unused-deps.mjs && node scripts/check-e2e-widget-coverage.mjs && node scripts/check-security.mjs && node scripts/check-security-selftest.mjs && pnpm --filter @skywalking-horizon-ui/bff run i18n:validate && pnpm --filter @skywalking-horizon-ui/bff run templates:validate",
     "lint:budget": "node scripts/check-source-budget.mjs",
     "lint:i18n": "node scripts/check-ui-i18n.mjs && pnpm --filter @skywalking-horizon-ui/bff run i18n:validate",
     "lint:promises": "node scripts/check-ui-promises.mjs",

--- a/scripts/check-e2e-widget-coverage.mjs
+++ b/scripts/check-e2e-widget-coverage.mjs
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// e2e widget-form coverage. The template-fidelity spec proves a rendered
+// dashboard matches the template that declared it, and it dispatches on widget
+// TYPE: each form names the element proving that branch actually drew. If a
+// bundled template starts using a form the spec has no proof for, the spec does
+// not fail — it silently stops covering that form.
+//
+// This lives here rather than in the spec because it drives nothing and
+// observes nothing: it reads two files. Inside the Playwright project it cost a
+// browser and a full OAP + BanyanDB stack to answer a question about disk, and
+// could fail the UI e2e project without the product being involved at all.
+//
+// The SELECTOR is checked, not just the key. `line: ''` keeps the key while the
+// spec's own dispatch treats it as absent and skips the assertion — a hole that
+// leaves both sides green and the form uncovered.
+//
+// Its adversarial fixtures run on every invocation, before the real check. A
+// coverage gate that cannot demonstrate failure is decoration, and this one
+// depends on regexes over a file it does not own, so "still parses" is a claim
+// worth re-proving each time rather than trusting.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SPEC = resolve(root, 'test/e2e/playwright/specs/ui/template-fidelity.spec.ts');
+const FIXTURE = resolve(root, 'test/e2e/playwright/specs/fixture.ts');
+const TEMPLATES = resolve(root, 'apps/bff/src/bundled_templates/layers');
+
+/** Forms the fixture must keep exercising; losing one silently guts the spec. */
+const REQUIRED_FORMS = ['line', 'top'];
+
+/**
+ * Every problem with one (spec, template) pair, as plain strings.
+ *
+ * Pure so the fixtures below can drive it without touching the repo.
+ */
+function coverageIssues(specSrc, template, layer) {
+  const issues = [];
+  const block = specSrc.match(/const RENDERED_AS[^=]*=\s*\{([\s\S]*?)\n\};/);
+  if (!block) return [`could not find the RENDERED_AS map — has it been renamed?`];
+
+  // Key AND selector. A blank selector is a missing proof, not a proof.
+  const proofs = new Map();
+  for (const m of block[1].matchAll(/^\s*([a-z][a-z0-9]*)\s*:\s*'([^']*)'/gm)) {
+    proofs.set(m[1], m[2].trim());
+  }
+  if (proofs.size === 0) return ['parsed the RENDERED_AS map but found no widget forms in it'];
+  for (const [form, selector] of proofs) {
+    if (selector === '') {
+      issues.push(
+        `widget form "${form}" has an empty selector in RENDERED_AS — the spec skips its rendered-proof entirely`,
+      );
+    }
+  }
+
+  // Ungated widgets only, matching what the spec asserts: a `visibleWhen`
+  // widget is dropped per entity, so it is not guaranteed to render.
+  const used = new Set(
+    ['service', 'endpoint', 'instance']
+      .flatMap((scope) => template.dashboards?.[scope] ?? [])
+      .filter((w) => w?.visibleWhen === undefined && typeof w?.type === 'string')
+      .map((w) => w.type),
+  );
+  if (used.size === 0) return [`${layer} declares no ungated widgets — wrong layer?`];
+
+  for (const type of used) {
+    if (!proofs.has(type)) {
+      issues.push(
+        `no rendered-proof defined for widget type "${type}" — add one to RENDERED_AS in template-fidelity.spec.ts, or its assertions silently stop covering it`,
+      );
+    }
+  }
+  // `card` and `table` are not reachable from this fixture: general declares
+  // neither. They live in the Kubernetes layers, so coverage arrives with the
+  // planned k8s monitoring case. Until then this keeps the omission visible
+  // rather than letting it pass as covered.
+  for (const form of REQUIRED_FORMS) {
+    if (!used.has(form)) issues.push(`the ${layer} fixture no longer renders any "${form}" widget`);
+  }
+  return issues;
+}
+
+const GOOD_SPEC = "const RENDERED_AS: Record<string, string> = {\n  line: '.time-chart',\n  top: '.top-list',\n};";
+const GOOD_TEMPLATE = {
+  dashboards: { service: [{ type: 'line' }, { type: 'top' }], endpoint: [], instance: [] },
+};
+
+/** Each fixture must produce an issue mentioning `expect`; the good pair must produce none. */
+const FIXTURES = [
+  ['a blank selector', GOOD_SPEC.replace("'.time-chart'", "''"), GOOD_TEMPLATE, 'empty selector'],
+  ['a renamed map', GOOD_SPEC.replace('RENDERED_AS', 'RENDERED_MAP'), GOOD_TEMPLATE, 'renamed'],
+  [
+    'an unproven widget form',
+    GOOD_SPEC,
+    { dashboards: { service: [{ type: 'line' }, { type: 'top' }, { type: 'heatmap' }] } },
+    'heatmap',
+  ],
+  [
+    'a form the fixture stopped rendering',
+    GOOD_SPEC,
+    { dashboards: { service: [{ type: 'line' }] } },
+    'top',
+  ],
+];
+
+function selfTest() {
+  const clean = coverageIssues(GOOD_SPEC, GOOD_TEMPLATE, 'selftest');
+  if (clean.length > 0) {
+    return `the healthy fixture reported ${clean.length} issue(s): ${clean.join('; ')}`;
+  }
+  for (const [name, spec, template, expected] of FIXTURES) {
+    const found = coverageIssues(spec, template, 'selftest');
+    if (!found.some((i) => i.includes(expected))) {
+      return `fixture "${name}" was not caught (expected an issue mentioning "${expected}", got: ${found.join('; ') || 'none'})`;
+    }
+  }
+  return null;
+}
+
+const broken = selfTest();
+if (broken) {
+  console.error(`check-e2e-widget-coverage: SELF-TEST FAILED — ${broken}`);
+  console.error('the gate cannot be trusted until this passes; it would report zero findings.');
+  process.exit(1);
+}
+
+const layerMatch = readFileSync(FIXTURE, 'utf8').match(/export const LAYER\s*=\s*'([^']+)'/);
+if (!layerMatch) {
+  console.error(`check-e2e-widget-coverage: could not read LAYER from ${FIXTURE}`);
+  process.exit(1);
+}
+const layer = layerMatch[1];
+const issues = coverageIssues(
+  readFileSync(SPEC, 'utf8'),
+  JSON.parse(readFileSync(resolve(TEMPLATES, `${layer}.json`), 'utf8')),
+  layer,
+);
+
+if (issues.length > 0) {
+  for (const issue of issues) console.error(`check-e2e-widget-coverage: ${issue}`);
+  process.exit(1);
+}
+console.log(
+  `check-e2e-widget-coverage: ok — ${layer}'s widget forms all have a non-empty rendered-proof (${FIXTURES.length} self-test fixtures passed)`,
+);

--- a/test/e2e/cases/deployment/e2e.yaml
+++ b/test/e2e/cases/deployment/e2e.yaml
@@ -167,9 +167,13 @@ verify:
     #    Three things have to line up, and each was learned by watching this
     #    check open on data the page could not draw:
     #      - the VALUES, not the edge: an edge exists from the topology alone;
-    #      - NON-NULL values, not a non-empty array: a series is one entry per
-    #        bucket and mostly null until data lands, and Sparkline renders no
-    #        `.sparkline` element at all for an all-null series;
+    #      - TWO non-null values, not one. A series is one entry per bucket and
+    #        mostly null until data lands, and Sparkline needs two finite
+    #        points to have a line to draw — below that it renders
+    #        `.sparkline-empty` instead. A gate that opened on a single
+    #        populated bucket therefore declared the fixture ready while the
+    #        panel the browser case asserts on could still only draw em
+    #        dashes, which is a red case on a healthy cluster;
     #      - the metrics the panel actually DRAWS, for the PAIR the spec opens.
     #        `write` / `query` are the primary rows of liaison->data, which is
     #        the pair the browser case selects and the only one this fixture
@@ -184,7 +188,7 @@ verify:
             swctl --display json --base-url=http://${service_skywalking_oap_host}:${service_skywalking_oap_12800}/graphql \
               service ls | yq e '.[] | select(.name == "e2e-banyandb") | .id' - \
           )" \
-          | yq -P '{"hasEdgeSeries": ([.calls[]? | (.clientMetricSeries // {}) | to_entries[]? | select(.key == "write" or .key == "query") | .value // [] | map(select(. != null)) | select(length > 0)] | length > 0)}'
+          | yq -P '{"hasEdgeSeries": ([.calls[]? | (.clientMetricSeries // {}) | to_entries[]? | select(.key == "write" or .key == "query") | .value // [] | map(select(. != null)) | select(length > 1)] | length > 0)}'
       expected: expected/has-edge-series.yml
 
     # 4. The browser half — the actual test.

--- a/test/e2e/playwright/specs/admin/pages.spec.ts
+++ b/test/e2e/playwright/specs/admin/pages.spec.ts
@@ -50,9 +50,9 @@ test('the capture history page mounts with its per-catalog filters', async ({ pa
   // rather than content the wire cases created. Populating it would mean
   // driving a capture through the debugger UI, which would race the wire
   // cases' mutations.
-  // The catalog chips BY NAME, in order. `.dh button` also matches "clear
-  // all", so a count alone was satisfied by a page that rendered its header
-  // and no filter row at all — the one thing this asserts.
+  // The catalog chips BY NAME, in order. `.dh button` counted the four chips
+  // plus the conditional "clear all", so the number it produced could not say
+  // WHICH buttons had rendered — naming them can.
   await expect(page.locator('.dh__filterchip')).toHaveText([
     /^all\b/,
     /^mal\b/,
@@ -92,8 +92,12 @@ test('the layer dashboard admin mounts', async ({ page, pageErrors }) => {
   await page.goto('/admin/layer-dashboards');
   await expect(page.locator('#app')).toBeVisible();
 
-  // templates.mode is live, so this page renders what OAP holds, and the layer
-  // roster is what proves the seed-and-read round trip.
+  // This editor's roster is the BUNDLED list, by design: the disk bundle
+  // reaches the runtime through initialization and read-only mode, plus this
+  // page's bundled-preview source, which is what the editor diffs against.
+  // So the rows prove the page mounted and the bundle loaded — they say
+  // nothing about OAP, and cannot: they render identically with the template
+  // store unreachable. The OAP half is asserted from the sync badge below.
   //
   // The roster is behind a click. The page mounts with its layer list
   // COLLAPSED and opens on whichever template sorts first, so on load the only
@@ -112,9 +116,19 @@ test('the layer dashboard admin mounts', async ({ page, pageErrors }) => {
   // Layer keys are enum values rendered verbatim in every locale, which is
   // what makes them safe to match on.
   expect(await rows.count()).toBeGreaterThan(2);
+  const layerRow = rows.filter({
+    has: page.locator('.key-tag', { hasText: new RegExp(`^${LAYER}$`, 'i') }),
+  });
+  await expect(layerRow, `the ${LAYER} template is missing from the bundled roster`).toHaveCount(1);
+
+  // THIS is the seed-and-read round trip. The badge compares the bundled copy
+  // against the OAP-stored one, so `synced` (byte-identical) and `diverged`
+  // (OAP holds a different copy, and OAP wins at render) both prove OAP
+  // answered. `bundled-fallback` — or no badge at all — is the break: it means
+  // the template store had nothing for this layer.
   await expect(
-    rows.locator('.key-tag').filter({ hasText: new RegExp(`^${LAYER}$`, 'i') }),
-    `the ${LAYER} template did not come back from OAP`,
+    layerRow.locator('.tsb--synced, .tsb--diverged'),
+    `${LAYER} has no OAP-stored copy — boot seeding into the template store did not land`,
   ).toHaveCount(1);
 
   expect(pageErrors).toEqual([]);

--- a/test/e2e/playwright/specs/deployment/banyandb.spec.ts
+++ b/test/e2e/playwright/specs/deployment/banyandb.spec.ts
@@ -92,6 +92,15 @@ test('clicking a deployment edge opens its client/server sparklines', async ({
   page,
   pageErrors,
 }) => {
+  // The fixture runs two liaisons and two data nodes, so the pair can hold
+  // four edges and the one carrying writes may be last. Opening each costs a
+  // panel load plus the wait below, which does not fit the 60s default — and
+  // overrunning it reports a bare timeout instead of the assertion's own
+  // diagnosis, so a healthy-but-unlucky ordering would look like a product
+  // failure. Stated as a number with its arithmetic rather than `test.slow()`,
+  // which silently means "×3".
+  test.setTimeout(150_000);
+
   await page.goto(`/layer/${BANYANDB_LAYER}/deployment`);
   await expect(page.locator('.lg-role-name').first()).toBeVisible({ timeout: 60_000 });
 
@@ -127,24 +136,58 @@ test('clicking a deployment edge opens its client/server sparklines', async ({
   });
   const flowRows = pair.locator('tbody tr');
   await expect(flowRows.first()).toBeVisible({ timeout: 60_000 });
-  await flowRows.first().click();
 
-  // The ROWS are the edge configuration reaching the panel: one per metric id
-  // the template declares for the pair, pairing `lineClient` (measured at the
-  // caller) with `lineServer` (measured at the callee).
-  await expect(page.locator('.ip-edge-rows').first()).toBeVisible({ timeout: 60_000 });
-  await expect(page.locator('.ip-edge-rows .ip-edge-row').first()).toBeVisible();
-
-  // And a DRAWN chart, not just the row. Sparkline renders `.sparkline` only
-  // when the series has a non-null point and `.sparkline-empty` otherwise, so
-  // asserting the rows alone passed on a panel of em dashes. The readiness
-  // check ahead of this proves the same pair's `write` / `query` series
-  // through the endpoint the page reads, so an empty chart here is a defect,
-  // not a cold cluster.
+  // The edge that HAS the traffic, read off the table rather than assumed. The
+  // group holds one row per liaison×data pairing, and which of them carried the
+  // writes depends on how the cluster hashed the data — so row one is a coin
+  // flip. The table already prints every edge's Write/s and Query/s (`primary`
+  // in the pair's config, `td.fl-primary` on screen) and renders an em dash for
+  // a null, so the page's own answer names the row worth opening.
+  const withTraffic = flowRows.filter({ has: page.locator('td.fl-primary', { hasText: /\d/ }) });
   await expect(
-    page.locator('.ip-edge-rows .sparkline').first(),
-    'the liaison -> data edge rendered no sparkline — the panel drew em dashes for a pair that carries every write',
-  ).toBeVisible({ timeout: 60_000 });
+    withTraffic.first(),
+    'no liaison -> data edge reported a Write/s or Query/s value — the pair that carries every write is idle',
+  ).toBeVisible({ timeout: 30_000 });
+  // The DRAWN chart on a primary row. Sparkline needs two finite points and
+  // renders `.sparkline-empty` below that, so asserting rows alone passed on a
+  // panel of em dashes — which is why the readiness check ahead of this waits
+  // for two points rather than one. Scoping matters as much: an unscoped
+  // `.sparkline` was satisfied by the pair's `bytes` or `err` rows, the
+  // loophole that same filter was narrowed to `write` / `query` to close.
+  const primaryChart = page
+    .locator('.ip-edge-rows .ip-edge-row')
+    .filter({ has: page.locator('.ip-edge-row-label', { hasText: /^(Write\/s|Query\/s)\b/ }) })
+    .locator('.sparkline');
+
+  // Each reporting edge in turn, because a cell and a chart do not need the
+  // same amount of data: the cell prints from ONE non-null bucket while the
+  // line needs two, so an edge can report traffic and still legitimately draw
+  // nothing. The readiness check proves only that SOME call in the pair has a
+  // drawable series, and this finds it. Bounded to the edges that reported a
+  // value — usually one — rather than sweeping every pairing in the group.
+  const candidates = await withTraffic.count();
+  let drawn = false;
+  for (let i = 0; i < candidates && !drawn; i += 1) {
+    await page.getByRole('button', { name: 'Flows' }).click();
+    await withTraffic.nth(i).click();
+    // The ROWS are the edge configuration reaching the panel: one per metric
+    // id the template declares for the pair, pairing `lineClient` (measured at
+    // the caller) with `lineServer` (measured at the callee).
+    await expect(page.locator('.ip-edge-rows').first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.ip-edge-rows .ip-edge-row').first()).toBeVisible();
+    // The panel's rows render from config and fill from the edge's own fetch,
+    // so this has to outlast that query — but it is a NEGATIVE wait paid once
+    // per candidate, so it stays as short as that allows.
+    drawn = await primaryChart
+      .first()
+      .waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+  }
+  expect(
+    drawn,
+    `none of the ${candidates} liaison -> data edge(s) reporting a value drew a Write/s or Query/s sparkline`,
+  ).toBe(true);
 
   expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
 });

--- a/test/e2e/playwright/specs/deployment/mal-debug.spec.ts
+++ b/test/e2e/playwright/specs/deployment/mal-debug.spec.ts
@@ -69,9 +69,17 @@ test('the MAL debugger samples the collector metrics', async ({ page, pageErrors
   // nothing, so asserting the page or the session state would pass on a
   // debugger that samples and shows nothing.
   await expect(page.locator('.mal__records').first()).toBeVisible({ timeout: 240_000 });
-  // The container is the `v-else` of that empty state, so it already implies a
-  // record exists — but a card that fails to render leaves it standing empty.
-  await expect(page.locator('.mal__rec').first()).toBeVisible({ timeout: 45_000 });
+
+  // A record with STEPS in it. Asserting the card itself proved nothing: it is
+  // the sole `v-for` child of a container that is already the `v-else` of the
+  // empty branch, so it could not fail once the line above passed. The step
+  // count is what "the debugger sampled something" actually means — a capture
+  // that matched the rule but walked no transformation renders a card with
+  // "0 steps".
+  await expect(
+    page.locator('.mal__rec').first().locator('.mal__recmeta'),
+    'the first MAL record captured no transformation steps',
+  ).toHaveText(/[1-9]\d* steps/, { timeout: 45_000 });
 
   expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
 });

--- a/test/e2e/playwright/specs/support/diagnostics.ts
+++ b/test/e2e/playwright/specs/support/diagnostics.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import type { Page } from '@playwright/test';
 import { test as base, expect } from '@playwright/test';
 
 /**
@@ -57,26 +58,48 @@ import { test as base, expect } from '@playwright/test';
  * people learn to disable.
  */
 
-/** Vue's production error handler prefixes component errors with this. */
-const VUE_COMPONENT_ERROR = /^\[Vue warn\]|Unhandled error during execution|^ReferenceError|^TypeError/;
+/**
+ * What Vue's production build actually prints for a component error.
+ *
+ * Its handler calls `console.error(err)` with the raw Error object, so the line
+ * begins with the error's own class name and nothing else — `TypeError: …`,
+ * `ReferenceError: …`, `Error: …`. Matching the class generally is deliberate:
+ * pinning two of them let every other class blank the page silently.
+ *
+ * The dev-only strings are NOT matched. Vue emits `[Vue warn]` and `Unhandled
+ * error during execution` through `console.warn`, and only outside production,
+ * while this promotion is guarded on `type === 'error'` — so including them
+ * matched nothing and implied coverage the fixture did not have.
+ */
+const VUE_COMPONENT_ERROR = /^\w*Error\b/;
 
 export const test = base.extend<{ pageErrors: string[] }>({
   pageErrors: async ({ page }, use, testInfo) => {
     const pageErrors: string[] = [];
     const consoleLines: string[] = [];
 
-    page.on('pageerror', (e) => pageErrors.push(`${e.name}: ${e.message}`));
-    page.on('console', (msg) => {
-      const type = msg.type();
-      if (type === 'error' || type === 'warning') {
-        consoleLines.push(`[${type}] ${msg.text()}`);
-      }
-      // A component that threw during setup/render reaches here, not
-      // `pageerror`, in a production build.
-      if (type === 'error' && VUE_COMPONENT_ERROR.test(msg.text().trim())) {
-        pageErrors.push(`console: ${msg.text().split('\n')[0]}`);
-      }
-    });
+    const record = (target: Page): void => {
+      target.on('pageerror', (e) => pageErrors.push(`${e.name}: ${e.message}`));
+      target.on('console', (msg) => {
+        const type = msg.type();
+        if (type === 'error' || type === 'warning') {
+          consoleLines.push(`[${type}] ${msg.text()}`);
+        }
+        // A component that threw during setup/render reaches here, not
+        // `pageerror`, in a production build.
+        if (type === 'error' && VUE_COMPONENT_ERROR.test(msg.text().trim())) {
+          pageErrors.push(`console: ${msg.text().split('\n')[0]}`);
+        }
+      });
+    };
+
+    // Recorded per CONTEXT, not per page. Specs that open a page of their own —
+    // the deep-link flows do, to prove a param consumed on first mount — would
+    // otherwise assert against an array nothing ever wrote to, so their
+    // `expect(pageErrors).toEqual([])` could not fail whatever that page did.
+    const context = page.context();
+    context.pages().forEach(record);
+    context.on('page', record);
 
     await use(pageErrors);
 

--- a/test/e2e/playwright/specs/ui/entities.spec.ts
+++ b/test/e2e/playwright/specs/ui/entities.spec.ts
@@ -42,9 +42,19 @@ test('the instance tab renders a dashboard for a real instance', async ({ page, 
   // selected — so the assertion passed whether or not an entity resolved,
   // which is the thing it exists to prove.
   await expect(page.locator('.ib-row.on')).toContainText('provider1', { timeout: 45_000 });
-  // And the grid drew something for it: a resolved entity with 68 empty tiles
-  // is the exact symptom of the wrong-scope query described above.
-  await expect(page.locator('.widget .time-chart').first()).toBeVisible({ timeout: 45_000 });
+  // And the grid drew DATA, not merely tiles. A `.time-chart` renders for an
+  // all-null series too, so it cannot tell a resolved scope from an empty one
+  // — the very symptom described above. The widget COUNT can: this scope
+  // declares 74 widgets of which 71 are gated on an `exists` MQE, and a gated
+  // widget whose metric came back with no non-null value is dropped before the
+  // page ever sees it. Anything above the 3 ungated ones therefore proves
+  // instance-scope metrics arrived.
+  await expect
+    .poll(async () => widgets.count(), {
+      timeout: 45_000,
+      message: 'only the ungated widgets rendered — instance-scope metrics came back empty',
+    })
+    .toBeGreaterThan(3);
 
   expect(pageErrors).toEqual([]);
 });
@@ -57,6 +67,13 @@ test('the endpoint tab renders a dashboard for a real endpoint', async ({ page, 
   await expect(widgets.first()).toBeVisible({ timeout: 45_000 });
   // Scoped to the picked row for the same reason as the instance tab.
   await expect(page.locator('.ib-row.on')).toContainText(AN_ENDPOINT, { timeout: 45_000 });
+  // A render check only, deliberately. The chart element appears even for an
+  // all-null series, so it proves the widget dispatched, not that data arrived
+  // — and the count trick used on the instance tab does not transfer: this
+  // scope declares 5 widgets with a single gated one ("MQ Avg Consuming
+  // Latency"), which the demo app correctly never reports. Proving endpoint
+  // data would need a readiness check on an endpoint metric, not a stricter
+  // assertion here.
   await expect(page.locator('.widget .time-chart').first()).toBeVisible({ timeout: 45_000 });
 
   expect(pageErrors).toEqual([]);

--- a/test/e2e/playwright/specs/ui/layout.spec.ts
+++ b/test/e2e/playwright/specs/ui/layout.spec.ts
@@ -29,7 +29,7 @@ import { LAYER } from '../fixture.js';
 // says it identically on every platform. Screenshots stay what they should
 // be: evidence attached to a failure.
 
-test('the dashboard widget grid tiles rather than collapsing', async ({ page }) => {
+test('the dashboard widget grid tiles rather than collapsing', async ({ page, pageErrors }) => {
   await page.goto(`/layer/${LAYER}/service`);
 
   // `.widget`, not `.sw-card`: the service picker is also a card, so a
@@ -54,6 +54,11 @@ test('the dashboard widget grid tiles rather than collapsing', async ({ page }) 
 
   const topRow = boxes.filter((b) => Math.abs(b.y - boxes[0].y) < 8);
   expect(topRow.length, 'widgets stacked vertically instead of tiling').toBeGreaterThan(1);
+
+  // Destructured deliberately: the diagnostics fixture is lazy, so a file that
+  // imports this `test` without asking for `pageErrors` attaches no recorders
+  // at all and collects nothing.
+  expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
 });
 
 // Each path names the element that proves the page has CONTENT to overflow
@@ -68,7 +73,7 @@ const RENDERED: [string, string][] = [
   ['/', '.sw-card.tile, .widget'],
 ];
 
-test('no page scrolls sideways', async ({ page }) => {
+test('no page scrolls sideways', async ({ page, pageErrors }) => {
   for (const [path, ready] of RENDERED) {
     await page.goto(path);
     await expect(page.locator(ready).first()).toBeVisible({ timeout: 45_000 });
@@ -90,4 +95,6 @@ test('no page scrolls sideways', async ({ page }) => {
       )
       .toBeLessThanOrEqual(1);
   }
+
+  expect(pageErrors, 'an uncaught error during mount blanks the page').toEqual([]);
 });

--- a/test/e2e/playwright/specs/ui/overview.spec.ts
+++ b/test/e2e/playwright/specs/ui/overview.spec.ts
@@ -37,13 +37,17 @@ test('the services overview renders its widget vocabulary', async ({ page, pageE
   const tiles = page.locator('.sw-card.tile');
   await expect(tiles.first()).toBeVisible({ timeout: 45_000 });
   await expect.poll(async () => tiles.count(), { timeout: 45_000 }).toBeGreaterThan(1);
-  // `.count` renders "—" when the value is null, so its visibility is
-  // satisfied by an overview that resolved nothing. The fixture drives traffic
-  // through general, so at least one KPI tile must carry a digit.
+  // `.kpi-value`, NOT `.count`. The count row is the tile's service tally,
+  // which is always numeric — it prints "0" for a layer OAP never answered for
+  // — so requiring a digit there passed on exactly the build this is meant to
+  // catch. The KPI rows are the MQE-bound ones (general's is
+  // `sum(top_n(service_cpm, …))`, the metric the case's readiness check already
+  // gates on), and they render an em dash when nothing bound.
   await expect
     .poll(
-      async () => (await tiles.locator('.count').allTextContents()).filter((t) => /\d/.test(t)).length,
-      { timeout: 60_000, message: 'every KPI tile rendered an em dash — the overview bound no values' },
+      async () =>
+        (await tiles.locator('.kpi-value').allTextContents()).filter((t) => /\d/.test(t)).length,
+      { timeout: 30_000, message: 'every KPI row rendered an em dash — the overview bound no values' },
     )
     .toBeGreaterThan(0);
 

--- a/test/e2e/playwright/specs/ui/template-fidelity.spec.ts
+++ b/test/e2e/playwright/specs/ui/template-fidelity.spec.ts
@@ -144,48 +144,55 @@ async function assertScopeMatchesTemplate(page: Page, scope: string, path: strin
       `widget "${w.title}" should render as type ${w.type}`,
     ).toHaveClass(new RegExp(`\\btype-${w.type}\\b`));
 
+    // A missing OR blank proof is a coverage hole, not a widget to skip. The
+    // old `if (proof)` treated `line: ''` as "nothing to check" and moved on,
+    // so a form could lose its rendered-proof with this spec and its lint gate
+    // both green. Failing here makes that impossible to do quietly.
     const proof = RENDERED_AS[w.type];
-    if (proof) {
-      if (FIXTURE_GUARANTEES_DATA.has(w.type)) {
-        await expect(
-          tile.locator(proof).first(),
-          `widget "${w.title}" (${w.type}) carries the type class but rendered nothing`,
-        ).toBeVisible();
-      } else {
-        // Content OR an explicit "no data" — never neither, and never an
-        // error. The widget's own error text is returned rather than swallowed
-        // so the failure names the OAP problem instead of just the tile.
-        const body = tile.locator('.w-body');
-        await expect
-          .poll(
-            async () => {
-              if (
+    if (!proof) {
+      throw new Error(
+        `widget "${w.title}" is type ${w.type}, which has no rendered-proof in RENDERED_AS — add one, or this spec silently stops covering that form`,
+      );
+    }
+    if (FIXTURE_GUARANTEES_DATA.has(w.type)) {
+      await expect(
+        tile.locator(proof).first(),
+        `widget "${w.title}" (${w.type}) carries the type class but rendered nothing`,
+      ).toBeVisible();
+    } else {
+      // Content OR an explicit "no data" — never neither, and never an
+      // error. The widget's own error text is returned rather than swallowed
+      // so the failure names the OAP problem instead of just the tile.
+      const body = tile.locator('.w-body');
+      await expect
+        .poll(
+          async () => {
+            if (
+              await body
+                .locator(proof)
+                .first()
+                .isVisible()
+                .catch(() => false)
+            ) {
+              return 'content';
+            }
+            const text =
+              (
                 await body
-                  .locator(proof)
+                  .locator(EMPTY_STATE)
                   .first()
-                  .isVisible()
-                  .catch(() => false)
-              ) {
-                return 'content';
-              }
-              const text =
-                (
-                  await body
-                    .locator(EMPTY_STATE)
-                    .first()
-                    .textContent()
-                    .catch(() => null)
-                )?.trim() ?? '';
-              if (NO_DATA.test(text)) return 'no data';
-              return text === '' ? 'nothing rendered' : text;
-            },
-            {
-              timeout: 45_000,
-              message: `widget "${w.title}" (${w.type}) rendered neither content nor "no data"`,
-            },
-          )
-          .toMatch(/^(content|no data)$/);
-      }
+                  .textContent()
+                  .catch(() => null)
+              )?.trim() ?? '';
+            if (NO_DATA.test(text)) return 'no data';
+            return text === '' ? 'nothing rendered' : text;
+          },
+          {
+            timeout: 45_000,
+            message: `widget "${w.title}" (${w.type}) rendered neither content nor "no data"`,
+          },
+        )
+        .toMatch(/^(content|no data)$/);
     }
 
     // Layout comes from the template too. `span` is grid columns; if it stops
@@ -253,53 +260,38 @@ test('the instance dashboard renders exactly what its template declares', async 
   expect(jvmTitles.length, 'the instance template no longer declares JVM-gated widgets').toBeGreaterThan(0);
   expect(nodeTitles.length, 'the instance template no longer declares Node.js-gated widgets').toBeGreaterThan(0);
 
-  const shown = async (titles: string[]): Promise<number> => {
-    let n = 0;
-    for (const t of titles) if (await page.getByText(t, { exact: true }).count()) n += 1;
-    return n;
-  };
-  expect(
-    await shown(jvmTitles),
-    'no JVM-gated widget rendered for a Java instance — the visibleWhen gate is stuck shut',
-  ).toBeGreaterThan(0);
-  expect(
-    await shown(nodeTitles),
-    'a Node.js-gated widget rendered for a Java instance — the visibleWhen gate is stuck open',
-  ).toBe(0);
+  // BOTH counts from ONE DOM snapshot. Judged separately, the absence check
+  // was read at a different instant from its positive control — and the grid
+  // is unmounted outright while the auto-refresh tick reloads, so a clear
+  // landing between the two made "no Node.js widget rendered" true of a page
+  // showing nothing at all. Two sequential sweeps of per-title queries have
+  // the same hole between them, however they are combined; one
+  // `allTextContents()` closes it, because both numbers then come from the
+  // same list and the zero can only be read at an instant where the JVM
+  // widgets prove the grid is there.
+  await expect
+    .poll(
+      async () => {
+        const rendered = new Set(
+          (await page.locator('.widget .w-head-title').allTextContents()).map((t) => t.trim()),
+        );
+        const jvm = jvmTitles.filter((t) => rendered.has(t)).length;
+        const node = nodeTitles.filter((t) => rendered.has(t)).length;
+        return `${jvm}/${node}`;
+      },
+      {
+        timeout: 45_000,
+        message:
+          'expected some JVM-gated widgets and no Node.js-gated ones on a Java instance — a leading 0 means the gate is stuck shut (or the grid was reloading), a trailing non-zero means it is stuck open',
+      },
+    )
+    .toMatch(/^[1-9]\d*\/0$/);
 
   expect(pageErrors).toEqual([]);
 });
 
-// A guard on the SPEC, not the product — so it is NOT a test. Every case here
-// costs a browser and a full OAP + BanyanDB stack, and this needs neither: it
-// reads two JSON files. It runs at module load, so an uncovered widget form
-// fails the whole file immediately rather than posing as a passing e2e case.
-//
-// What it protects: if a bundled template starts using a form the fixture
-// never renders, the assertions above quietly stop covering it. This turns
-// that into a decision rather than an accident.
-{
-  const covered = new Set(
-    ['service', 'endpoint', 'instance']
-      .flatMap((scope) => unconditional(widgetsOf(LAYER, scope)))
-      .map((w) => w.type),
-  );
-  for (const type of covered) {
-    if (!RENDERED_AS[type]) {
-      throw new Error(
-        `template-fidelity: no rendered-proof defined for widget type "${type}" — add one to RENDERED_AS or the assertions silently stop covering it`,
-      );
-    }
-  }
-  // `card` and `table` are not reachable from this fixture: general declares
-  // neither. They live in the Kubernetes layers — k8s.service carries 8 card
-  // and 6 table widgets, k8s_service 2 more tables — so coverage arrives with
-  // the planned k8s monitoring case, which shares its cluster fixture with
-  // the istio / rover work. Until then this keeps the omission visible rather
-  // than letting it pass as covered.
-  for (const form of ['line', 'top']) {
-    if (!covered.has(form)) {
-      throw new Error(`template-fidelity: the fixture no longer renders any "${form}" widget`);
-    }
-  }
-}
+// The guard that keeps RENDERED_AS in step with the bundled templates lives in
+// `scripts/check-e2e-widget-coverage.mjs`, run by `pnpm lint`. It drives
+// nothing and observes nothing — it reads two files — so paying a browser and
+// a full OAP + BanyanDB stack for it was wrong, and failing the UI e2e project
+// on it reported a spec-maintenance problem as a product one.


### PR DESCRIPTION
## Why

The assertions tightened in #118 were audited afterwards against the product source. Ten do not hold up: six pass on a build they describe as broken, two harness gaps mean whole specs cannot fail, and two comments state a reason that is false. Separately, the deployment case then failed on a healthy cluster because a readiness check and the assertion it gates disagreed about what "ready" means.

The suite was green for all of it. None of this is something a passing run can surface, which is the point.

## What

**Six assertions were vacuous.**

The layer-dashboard admin roster comes from the disk bundle by design: that page is the editor's bundled-preview source, and the bundle otherwise reaches the runtime only through initialization and read-only mode. Those rows therefore render identically with OAP's template store unreachable and can never be evidence about it — the old failure message ("did not come back from OAP") described something the check could not see. The OAP half now comes from the row's sync badge, which compares the bundled copy against the OAP-stored one; it admits `synced` and `diverged`, since both mean OAP answered, and treats `bundled-fallback` or a missing badge as the break.

The overview KPI check required a digit from the tile's service tally, which is always numeric and prints `0` for a layer OAP never answered for; it now reads the MQE-bound rows, which render an em dash when nothing binds.

`.widget .time-chart` renders for an all-null series, so it could not tell a resolved scope from an empty one. The instance tab now counts widgets instead: 71 of its 74 are gated on an `exists` MQE and are dropped before the page sees them when the metric returns no non-null value, so anything above the 3 ungated ones proves instance-scope metrics arrived. The endpoint scope cannot use the same discriminator — it declares one gated widget this fixture legitimately never reports — so that assertion is documented as a render check and claims nothing more.

The deployment sparkline was unscoped across the pair's seven metrics, so `bytes` or `err` satisfied it, re-admitting exactly what the readiness check had been narrowed to `write`/`query` to exclude. It is now scoped to the Write/s and Query/s rows.

The MAL record assertion could not fail once the line above it passed, being the sole child of a container that is already the non-empty branch; it now requires captured steps. And the `visibleWhen` gate check read its absence test and its positive control as two sequential DOM sweeps, so a grid unmounted by the auto-refresh tick satisfied both — both counts now come from a single `allTextContents()` snapshot, which is the only form of that check without a hole in the middle.

**The deployment case's two halves now agree.** Sparkline needs two finite points to have a line to draw and renders `.sparkline-empty` below that, while the readiness check opened on a single non-null bucket — so the gate declared the fixture ready while the panel could still only draw em dashes. The check now waits for two points. Which edge carries the writes is also a matter of how the cluster hashed the data, so the spec no longer pins a row: it reads the Write/s and Query/s values the Flows table already prints per edge, and tries each reporting edge until one draws, bounded to the edges that reported a value rather than sweeping the group. The fixture runs two liaisons and two data nodes, so that pair can hold four edges and the drawable one may be last — the test therefore states its own timeout with the arithmetic behind it, rather than inheriting a default it can exceed on a healthy-but-unlucky ordering and report as a bare timeout.

**Two harness gaps.** The diagnostics recorders attached only to the fixture's default page, so specs that open a page of their own asserted against an array nothing ever wrote to; they now attach per browser context. Its regex also matched two strings Vue emits only in dev builds and only through `console.warn`, while pinning two error classes let any other class blank a page silently — it now matches the error class generally, which is what Vue's production handler actually prints.

**The widget-form coverage guard leaves the browser project.** It drives nothing and observes nothing — it reads two files — so it cost a browser and a full OAP + BanyanDB stack to answer a question about disk, and failed the UI e2e project for a spec-maintenance problem the product had no part in. It is now `scripts/check-e2e-widget-coverage.mjs`, run by `pnpm lint`.

It checks the **selector**, not merely that the key exists. A blank one (`line: ''`) keeps the key while the spec's own dispatch treats the form as absent and skips its rendered-proof, so a form could lose its coverage with the spec and the gate both green — the spec now refuses that too, failing explicitly rather than moving on. And because the gate reads a file it does not own, through regexes, it runs adversarial fixtures on every invocation: a gate that has lost a check refuses to run instead of reporting zero findings.

**Two inaccurate comments.** The layout spec imported the diagnostics `test` without destructuring `pageErrors`, and the fixture is lazy, so no recorder ever attached; both tests now use it. The capture-history rationale described a failure the old locator could not have had.

## Validation

`pnpm lint` (including the new gate), `pnpm -r run type-check`, `pnpm license:check`, `pnpm lint:security`, `pnpm lint:deps` and the unit suites are green, as is `tsc` over the Playwright specs.

The new coverage gate was exercised rather than assumed. Injecting a widget form with no rendered-proof fails it; blanking a selector to `''` fails it; renaming `RENDERED_AS` fails it as an unparseable map. And deleting the empty-selector check from the gate itself makes its own fixtures fail it, so it cannot quietly degrade into a check that always passes.

The data-dependent fixes were checked against a live console. That mattered: the `GENERAL` row carries a **`diverged`** badge, so an assertion pinned to `synced` — the obvious reading — would fail on a healthy system, and accepting both states is deliberate. Alongside it, 12 of 15 KPI rows bind a real value and the instance grid renders 17 widgets against a floor of 3.

The e2e matrix is the real proof and runs on this PR.
