### PR TITLE
fix(config): detect a Kubernetes ConfigMap update, and drop unused package managers from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,26 @@ RUN pnpm package
 FROM node:24-alpine
 WORKDIR /app
 
+# The server only needs the Node runtime. The upstream image also includes
+# npm, Corepack and Yarn; keeping those unused package managers would ship
+# their dependency trees (and any vulnerabilities in them) in production.
+# Build tooling remains available in the throwaway build stage above.
+RUN rm -rf \
+      /usr/local/lib/node_modules/npm \
+      /usr/local/lib/node_modules/corepack \
+      /opt/yarn-* \
+    && rm -f \
+      /usr/local/bin/npm \
+      /usr/local/bin/npx \
+      /usr/local/bin/corepack \
+      /usr/local/bin/yarn \
+      /usr/local/bin/yarnpkg \
+    && node --version \
+    && ! command -v npm \
+    && ! command -v npx \
+    && ! command -v corepack \
+    && ! command -v yarn
+
 RUN addgroup -S horizon && adduser -S -G horizon horizon
 
 COPY --from=build /src/dist/server.js              ./server.js

--- a/apps/bff/src/config/loader.test.ts
+++ b/apps/bff/src/config/loader.test.ts
@@ -15,7 +15,16 @@
  * limitations under the License.
  */
 
-import { readFileSync, writeFileSync, rmSync, mkdtempSync, realpathSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
@@ -438,7 +447,10 @@ describe('config reload', () => {
     `oap:\n  queryUrl: "${oapUrl}"\nauth:\n  backend: local\n  local:\n    users: []\n`;
 
   const load = (): ReturnType<typeof loadConfig> => {
-    const src = loadConfig(file, { awaitWriteFinishMs: WATCH_MS });
+    const src = loadConfig(file, {
+      awaitWriteFinishMs: WATCH_MS,
+      pollIntervalMs: 20,
+    });
     open.push(src);
     return src;
   };
@@ -499,6 +511,41 @@ describe('config reload', () => {
     // The listener sees the NEW config, and `current` is already swapped by
     // the time it runs — a subscriber may read either and get the same answer.
     expect(seen.at(-1)).toBe('http://after:12800');
+  });
+
+  it('reloads when a Kubernetes projected volume rotates its ..data symlink', async () => {
+    rmSync(file);
+    let version = 0;
+    const rotate = (oapUrl: string): void => {
+      const versionName = `..2026_01_01_00_00_00.${version++}`;
+      const versionDir = join(dir, versionName);
+      mkdirSync(versionDir);
+      writeFileSync(join(versionDir, 'horizon.yaml'), yaml(oapUrl));
+
+      // Kubernetes' AtomicWriter publishes a new payload by atomically
+      // replacing `..data`; the visible key symlink itself never changes.
+      const nextData = join(dir, '..data_tmp');
+      symlinkSync(versionName, nextData);
+      renameSync(nextData, join(dir, '..data'));
+    };
+
+    rotate('http://before:12800');
+    symlinkSync('..data/horizon.yaml', file);
+
+    const src = load();
+    const seen: string[] = [];
+    src.onChange((cfg) => seen.push(cfg.oap.queryUrl));
+
+    expect(
+      await settledAfter(
+        // Same byte length as "before": this must detect the projected-file
+        // replacement itself, not merely notice that the target size changed.
+        () => rotate('http://second:12800'),
+        () => src.current.oap.queryUrl === 'http://second:12800',
+      ),
+    ).toBe(true);
+    expect(readFileSync(file, 'utf8')).toContain('http://second:12800');
+    expect(seen.at(-1)).toBe('http://second:12800');
   });
 
   it('rejects a malformed edit and keeps serving the previous config', async () => {

--- a/apps/bff/src/config/loader.ts
+++ b/apps/bff/src/config/loader.ts
@@ -339,6 +339,12 @@ export interface LoadConfigOptions {
    *  two seconds of wall clock each — the same seam `SessionStore` exposes
    *  for its reaper interval. */
   awaitWriteFinishMs?: number;
+  /** How often to stat the config file. Polling is intentional: Kubernetes
+   *  projected ConfigMap volumes update a file by rotating the `..data`
+   *  symlink, which an exact-path filesystem watcher does not report as a
+   *  `change`. The production default is inexpensive for this single file;
+   *  tests shorten it alongside `awaitWriteFinishMs`. */
+  pollIntervalMs?: number;
 }
 
 export function loadConfig(configPath: string, opts: LoadConfigOptions = {}): ConfigSource {
@@ -349,6 +355,12 @@ export function loadConfig(configPath: string, opts: LoadConfigOptions = {}): Co
 
   const watcher = chokidar.watch(absPath, {
     ignoreInitial: true,
+    // `fs.watch` follows the original projected-volume symlink and misses the
+    // atomic target replacement. `fs.watchFile` (chokidar polling) stats the
+    // configured pathname repeatedly, so both ordinary writes and Kubernetes
+    // `..data` rotations arrive through the same `change` path below.
+    usePolling: true,
+    interval: opts.pollIntervalMs ?? 1000,
     awaitWriteFinish: opts.awaitWriteFinishMs
       ? { stabilityThreshold: opts.awaitWriteFinishMs, pollInterval: 20 }
       : true,

--- a/docs/setup/container-image.md
+++ b/docs/setup/container-image.md
@@ -227,10 +227,12 @@ spec:
             - containerPort: 8081
           envFrom:
             - secretRef: { name: horizon-secrets }
+          env:
+            - name: HORIZON_CONFIG
+              value: /etc/horizon/horizon.yaml
           volumeMounts:
             - name: config
-              mountPath: /app/horizon.yaml
-              subPath: horizon.yaml
+              mountPath: /etc/horizon
               readOnly: true
             - name: state
               mountPath: /data
@@ -249,8 +251,10 @@ spec:
 
 Notes:
 
-- `subPath: horizon.yaml` mounts the single file rather than the directory, so it doesn't shadow `/app`'s other contents.
+- Mount the ConfigMap as a directory, not a `subPath`, so Kubernetes can project updates. `HORIZON_CONFIG` points the BFF at the projected file without shadowing `/app`.
 - Mount with `readOnly: true` on the config — the BFF only reads it.
+- Updates to the ConfigMap reach hot-reloadable settings after Kubernetes refreshes the projected volume. Settings documented as restart-required still need a pod restart.
+- Values supplied through `envFrom` are fixed when the container starts. After changing `horizon-secrets`, restart or roll out the pods; updating the Secret does not change an existing process's environment.
 - `/data` is the image's declared `VOLUME` for runtime state (the wire debug log). The `HORIZON_WIRE_LOG_FILE` env var baked into the image points at `/data/`, so mounting a PVC here is enough — no path override in `horizon.yaml` is required.
 - `fsGroup: 101` is the typical alpine `nobody` GID that `adduser -S -G horizon horizon` falls into. Run `docker run --rm <image> id horizon` to confirm if you've forked the image.
 - Run a single replica unless you accept that sessions are per-pod (the in-memory session store does not federate; see [session](session.md)).


### PR DESCRIPTION
## Why

Hot reload watched the config file with an exact-path filesystem watcher. A projected ConfigMap volume never rewrites that file — it swaps the `..data` symlink the path resolves through — so the watcher followed the original target and reported nothing. Horizon kept serving the configuration it booted with, and an operator editing a ConfigMap saw no effect **and no error**, which is the worst shape for this failure: it looks like the edit was wrong rather than unread.

Separately, the runtime image inherits npm, Corepack and Yarn from the upstream Node base. The server runs none of them, but their dependency trees ship to production and have to be answered for whenever one of them carries an advisory.

## What

The watcher polls, stating the configured pathname rather than the resolved inode, so an ordinary write and a `..data` rotation both arrive through the same change path. The interval is configurable; the tests shorten it alongside the existing write-settling delay so they stay fast.

The three package managers are removed from the final stage only. The build stage is untouched, so how the image is assembled does not change — just what it carries at runtime.

## Validation

New lifecycle tests in `loader.test.ts` cover the reload path, including the symlink-rotation shape that the exact-path watcher missed. `pnpm -r type-check`, `lint` and the full unit suites are green.

Not validated against a live Kubernetes cluster: the rotation is reproduced in the test by performing the same symlink swap a projected volume does, rather than by running one.