### PR TITLE
fix(audit): claim the request ticket before validating the token-usage range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,24 @@ English is the source of truth. Every UI string and every translatable template 
 
 Keep the changelog current as part of the change, not as an afterthought. Written from the operator's point of view — what's new on screen and what's now possible — never file-by-file implementation (that's the git log).
 
+**The shape of a version file.** In this order, and omit any section that has nothing in it:
+
+```
+# <version>
+
+## Breaking changes and migration        ← only when there is one
+## <Scope>                               ← one per feature area
+### Features
+### Fixes
+## Dependencies                          ← only when they moved
+```
+
+- **Breaking changes and migration come first, prefixed `**Breaking:**`.** A reader upgrading needs to know before anything else whether this release will refuse to start, or will start and behave differently. Say what changes, and say what to do about it — the entry is only complete once someone can act on it without reading the diff. A release with none has no such section: an empty heading reads as though we forgot.
+- **Then one section per SCOPE, and each scope splits into Features and Fixes.** The scope is the area an operator thinks in — *Dashboards*, *Traces, logs and events*, *Profiling*, *Sign-in and access control*, *Operating Horizon*. A reader who cares about one area reads one section and is done, instead of sifting a flat list for the entries that touch them. Keep the same scope names across releases so they are recognisable release to release; a scope with only features, or only fixes, keeps just the subsection it needs.
+- **A UI fix NAMES the widget, component or page it affects.** "Fixed a chart rendering issue" tells a reader nothing and cannot be checked against their own screen; *"the Kubernetes Node Status card showed a raw `1` instead of its conditions"* tells them exactly where to look and whether they saw it. Name the thing the way the interface names it, so it can be found by reading the screen rather than the source.
+- **Dependencies last, and only when they moved.** What was upgraded or replaced and what it means for the operator — a cleared advisory, a new minimum version, a behaviour that changes because a library did. Not a lockfile diff; a version bump nobody can observe is not an entry.
+
+
 **The layout: one file per version, kept forever.** `docs/changelog/<version>.md` — every shipped version has one, and so does the version in flight. There is **no root `CHANGELOG.md`**. Each file is a website page: an H1 title carrying the version, then the notes, listed in `docs/menu.yml` under **Release Notes**.
 
 - **Add your entry to the file whose version matches `package.json`.** The in-development version is the `*-dev` one there, so `1.0.0-dev` means `docs/changelog/1.0.0.md`. Any operator-visible capability — a new page / tab / widget, a new component flag, **bundled template changes** (a layer gaining a capability, new dashboards / widgets / metrics), a new admin surface — must be recorded in it. If a change alters what an operator sees or can do, it belongs in the changelog.

--- a/apps/ui/src/features/admin/audit/useTokenUsagePage.test.ts
+++ b/apps/ui/src/features/admin/audit/useTokenUsagePage.test.ts
@@ -91,3 +91,36 @@ describe('a seeded custom range', () => {
     expect(asked!.to - new Date(now).getTime()).toBeLessThanOrEqual(HOUR);
   });
 });
+
+describe('an outstanding request', () => {
+  /**
+   * The reply to a request the operator has already moved on from must not
+   * land. Validating the new range before claiming the generation left the old
+   * request live, so it resolved afterwards and painted its rows under a
+   * complaint about a range that never ran.
+   */
+  it('is orphaned when the next range is rejected', async () => {
+    const stale = {
+      hours: [{ hourBucket: 2026082310, at: 0, total: 999, credentials: 1, top: [] }],
+      range: { from: 1, to: 2 },
+    };
+    let settleFirst!: (v: typeof stale) => void;
+    const first = new Promise<typeof stale>((r) => { settleFirst = r; });
+    vi.spyOn(bff.adminAudit, 'tokenUsage').mockReturnValue(first as never);
+
+    const page = useTokenUsagePage();
+    const inFlight = page.load();                       // request A, still pending
+
+    page.setSpan(CUSTOM_RANGE_SENTINEL);
+    page.customStart.value = 'not-a-date';              // range B, invalid
+    await page.load();
+    expect(page.rangeError.value).toBe('Invalid date');
+
+    settleFirst(stale);                                 // A answers, far too late
+    await inFlight;
+
+    expect(page.hours.value, "a reply the operator moved on from painted its rows").toEqual([]);
+    expect(page.rangeError.value).toBe('Invalid date');
+    expect(page.loading.value, 'the orphaned request left the page spinning').toBe(false);
+  });
+});

--- a/apps/ui/src/features/admin/audit/useTokenUsagePage.ts
+++ b/apps/ui/src/features/admin/audit/useTokenUsagePage.ts
@@ -117,13 +117,19 @@ export function useTokenUsagePage() {
   }
 
   async function load(): Promise<void> {
+    // Claimed BEFORE the range is validated, so a rejected range still orphans
+    // whatever is already on the wire. Validating first let an older reply land
+    // afterwards and overwrite the inputs and results the operator was being
+    // told were invalid — the complaint stayed on screen above someone else's
+    // answer.
+    const mine = (generation += 1);
     const range = resolve();
     if (typeof range === 'string') {
       rangeError.value = range;
+      loading.value = false;
       return;
     }
     rangeError.value = null;
-    const mine = (generation += 1);
     // Cascade-clear: the previous span's hours must not sit under the spinner.
     hours.value = [];
     error.value = null;


### PR DESCRIPTION
## Why

The Token usage page validated the custom range and only then claimed its request ticket. A rejected range therefore left whatever was already on the wire un-orphaned: the older reply landed afterwards and overwrote the inputs and the results the operator was being told were invalid, so the complaint sat on screen above someone else's answer.

## What

The ticket is claimed first, so a refusal orphans the in-flight request as surely as a new query does. One line moved, plus the test that pins it.

`CLAUDE.md` also gains the changelog structure this repo now follows — breaking changes and migration first, one section per operator-facing scope split into features and fixes, dependencies last, and the rule that a UI fix names the widget, component or page it affects, since "fixed a chart rendering issue" cannot be checked against anyone's screen.

## Validation

The new test fails against the previous ordering and passes with it — the stale reply lands and its rows appear, which is what the assertion checks. `pnpm -r type-check`, `lint` and the full unit suites are green.