### PR TITLE
test(ui): guarantee a usable localStorage for every test file

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -65,6 +65,14 @@ export default defineConfig(({ command }) => ({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  // Vitest reads this file, so the setup lives here rather than in a
+  // `vitest.config.ts` — a separate config would replace this one and the
+  // `@` alias with it.
+  test: {
+    // ABSOLUTE: `test:unit` passes `--root src/`, so a relative path would
+    // resolve to `src/vitest.setup.ts` and fail to load.
+    setupFiles: [fileURLToPath(new URL('./vitest.setup.ts', import.meta.url))],
+  },
   server: {
     port: UI_DEV_PORT,
     strictPort: true,

--- a/apps/ui/vitest.setup.ts
+++ b/apps/ui/vitest.setup.ts
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Guarantee a working `localStorage` for every test file.
+ *
+ * jsdom installs one per environment, and the environment is torn down and
+ * rebuilt between files. Under heavy parallel load — the three workspace suites
+ * at once, straight after both app builds, which is exactly what the release
+ * script does — a file has been observed running against a global whose Storage
+ * methods were already gone: `TypeError: localStorage.clear is not a function`,
+ * in all four files that touch it at once. It reproduced once in a release and
+ * not in a dozen repeat runs, so it is a timing race, not a defect in those
+ * tests.
+ *
+ * Installing a Storage when the ambient one is unusable removes the dependency
+ * on that timing. It is deliberately NOT unconditional: when jsdom's own
+ * Storage is present the tests keep exercising the real thing.
+ */
+
+import { beforeEach } from 'vitest';
+
+function usable(store: unknown): boolean {
+  return (
+    typeof store === 'object' &&
+    store !== null &&
+    typeof (store as Storage).clear === 'function' &&
+    typeof (store as Storage).getItem === 'function' &&
+    typeof (store as Storage).setItem === 'function'
+  );
+}
+
+/** A Storage with the same observable behaviour as the browser's, including
+ *  the string coercion the real one performs. */
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length(): number {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(String(k)) ? map.get(String(k))! : null),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => void map.delete(String(k)),
+    setItem: (k: string, v: string) => void map.set(String(k), String(v)),
+  } as Storage;
+}
+
+function ensureStorage(name: 'localStorage' | 'sessionStorage'): void {
+  const current = (globalThis as Record<string, unknown>)[name];
+  if (usable(current)) return;
+  Object.defineProperty(globalThis, name, {
+    value: memoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+}
+
+ensureStorage('localStorage');
+ensureStorage('sessionStorage');
+beforeEach(() => {
+  ensureStorage('localStorage');
+  ensureStorage('sessionStorage');
+});


### PR DESCRIPTION
## Why

A **release run** failed with `TypeError: localStorage.clear is not a function` — 22 tests across all four UI test files that touch storage, at once.

jsdom installs `localStorage` per environment and tears that environment down between files. Under the load the release script creates — the three workspace suites concurrently, immediately after both app builds — a file ran against a global whose Storage methods were already gone. Node has no `localStorage` of its own (`ReferenceError`, checked), so this is jsdom's own object mid-teardown rather than something else leaking through.

It reproduced **once**, and not in a dozen repeats of the same commit, the same release clone, and the same build-then-test ordering. So it is a timing race, not a defect in those four tests — and it surfaces during a *release* rather than a PR precisely because that is where the load is. Left alone it will fail another release at random.

## What

`apps/ui/vitest.setup.ts` installs a Map-backed `Storage` **only when the ambient one is unusable**, checked before the run and before each test. A healthy environment keeps exercising jsdom's own implementation, so this does not quietly replace what the tests are meant to run against.

The `setupFiles` path is absolute. `test:unit` passes `--root src/`, and a relative `./vitest.setup.ts` resolves to `src/vitest.setup.ts` — which does not exist, and every suite then fails to load. I hit that on the first attempt.

The `test` block lives in `vite.config.ts` rather than a new `vitest.config.ts`, because a separate config would replace that file and take the `@` alias with it.

## Validation

- 698 UI tests pass, and `setup 1.09s` in the reporter confirms the file is actually loading — it silently does nothing if the path is wrong.
- The guard was proven with a temporary test that breaks `localStorage` the same way the release run saw it and asserts the next test gets a working one: both pass, and the file was removed afterwards.
- Full gate green: `type-check`, `lint`, 2,374 unit tests, `ui build`, `license-eye header check` (1660 files, 0 invalid).

No production code is touched — this is test infrastructure only.