### PR TITLE
Release 1.0.0, bump to 1.1.0-dev

### DIFF
--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/bff",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -197,7 +197,7 @@ app.addHook('onSend', (req, reply, payload, done) => {
 });
 
 /** Reported on /api/health and as the MCP server version an agent sees. */
-const HORIZON_VERSION = process.env.HORIZON_VERSION ?? '1.0.0';
+const HORIZON_VERSION = process.env.HORIZON_VERSION ?? '1.1.0-dev';
 
 const sessions = new SessionStore({ ttlMinutes: () => source.current.session.ttlMinutes });
 // API tokens ride the same pre-handler as the session cookie, so every route

--- a/apps/bff/src/server.ts
+++ b/apps/bff/src/server.ts
@@ -197,7 +197,7 @@ app.addHook('onSend', (req, reply, payload, done) => {
 });
 
 /** Reported on /api/health and as the MCP server version an agent sees. */
-const HORIZON_VERSION = process.env.HORIZON_VERSION ?? '1.0.0-dev';
+const HORIZON_VERSION = process.env.HORIZON_VERSION ?? '1.0.0';
 
 const sessions = new SessionStore({ ttlMinutes: () => source.current.session.ttlMinutes });
 // API tokens ride the same pre-handler as the session cookie, so every route

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/ui",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/docs/changelog/1.1.0.md
+++ b/docs/changelog/1.1.0.md
@@ -1,0 +1,3 @@
+# 1.1.0
+
+(In development — fill in highlights here before cutting the release.)

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -255,6 +255,8 @@ catalog:
 
   - name: "Release Notes"
     catalog:
+      - name: "1.1.0"
+        path: "/changelog/1.1.0"
       - name: "1.0.0"
         path: "/changelog/1.0.0"
       - name: "0.7.0"

--- a/docs/setup/container-image.md
+++ b/docs/setup/container-image.md
@@ -15,7 +15,7 @@ Registry: **GitHub Container Registry (GHCR)** at `ghcr.io/apache/skywalking-hor
 | `main` | Head of `main`. Moves on every merge. | Smoke-test the development branch. |
 
 ```sh
-docker pull ghcr.io/apache/skywalking-horizon-ui:0.7.0
+docker pull ghcr.io/apache/skywalking-horizon-ui:1.0.0
 docker pull ghcr.io/apache/skywalking-horizon-ui:<sha>
 ```
 
@@ -125,7 +125,7 @@ docker run -d --name horizon \
   -p 8081:8081 \
   -e NODE_OPTIONS=--max-old-space-size=1536 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
-  ghcr.io/apache/skywalking-horizon-ui:0.7.0
+  ghcr.io/apache/skywalking-horizon-ui:1.0.0
 ```
 
 ## How to load `horizon.yaml` into the container
@@ -141,7 +141,7 @@ docker run -d \
   --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
-  ghcr.io/apache/skywalking-horizon-ui:0.7.0
+  ghcr.io/apache/skywalking-horizon-ui:1.0.0
 ```
 
 Notes:
@@ -154,7 +154,7 @@ Notes:
 For immutable single-tenant deployments, build a child image that includes your config:
 
 ```dockerfile
-FROM ghcr.io/apache/skywalking-horizon-ui:0.7.0
+FROM ghcr.io/apache/skywalking-horizon-ui:1.0.0
 COPY horizon.yaml /app/horizon.yaml
 ```
 
@@ -222,7 +222,7 @@ spec:
         fsGroup: 101
       containers:
         - name: horizon
-          image: ghcr.io/apache/skywalking-horizon-ui:0.7.0
+          image: ghcr.io/apache/skywalking-horizon-ui:1.0.0
           ports:
             - containerPort: 8081
           envFrom:
@@ -268,7 +268,7 @@ docker run -d --name horizon \
   -p 8081:8081 \
   -v "$PWD/horizon.yaml:/app/horizon.yaml:ro" \
   -v horizon-state:/data \
-  ghcr.io/apache/skywalking-horizon-ui:0.7.0
+  ghcr.io/apache/skywalking-horizon-ui:1.0.0
 ```
 
 Without a mounted volume the writes still land in the container's writable layer at `/data/` (ephemeral, but at least non-failing). Mounting a volume is what makes them durable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-horizon-ui",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "private": true,
   "description": "Apache SkyWalking Horizon UI - next-generation web UI",
   "license": "Apache-2.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/api-client",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "1.0.0-dev",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skywalking-horizon-ui/design-tokens",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Release branch for 1.0.0. Two commits:

1. `Prepare release 1.0.0` — strips `-dev` from every package marker + `apps/bff/src/server.ts`; advances container-image docs to `1.0.0`. Tagged `v1.0.0` (the release-candidate commit the vote runs against).
2. `Prepare next release 1.1.0-dev` — bumps every marker to `1.1.0-dev` and seeds `docs/changelog/1.1.0.md` (with its `docs/menu.yml` entry) for the next cycle.

Merge after the [VOTE] passes so `main` returns to a `-dev` version with the release in its history. The `v1.0.0` tag is immutable and keeps pointing at commit 1 regardless of how this PR is merged.