### PR TITLE
A malformed permission grants nothing, not the area it starts with

### DIFF
--- a/apps/bff/src/rbac/verbs.test.ts
+++ b/apps/bff/src/rbac/verbs.test.ts
@@ -17,7 +17,12 @@
 
 import { describe, expect, it } from 'vitest';
 import { SCOPE_VERBS } from '../oauth/scopes.js';
-import { WILDCARD_EXEMPT_VERBS, hasVerb, resolveVerbsForRoles } from './verbs.js';
+import {
+  WILDCARD_EXEMPT_VERBS,
+  hasVerb,
+  isGrantRecognised,
+  resolveVerbsForRoles,
+} from './verbs.js';
 import { configSchema } from '../config/schema.js';
 import { BUILTIN_ROLES, BUILTIN_LANDING_BY_ROLE } from '../config/builtin-roles.js';
 
@@ -86,6 +91,48 @@ describe('resolveVerbsForRoles', () => {
     expect(resolveVerbsForRoles(policy, ['operator', 'unknown-role'], true)).toEqual(
       expect.arrayContaining(['*:read', 'rule:write', 'profile:enable']),
     );
+  });
+});
+
+/** Grant → required → expected. Shared with `apps/ui/src/state/auth.test.ts`,
+ *  which runs the SAME table through the UI's copy of this matcher: three
+ *  copies exist (BFF, auth store, Roles board) and they diverged together
+ *  once, so they are pinned to one answer rather than to one another. */
+export const MATCHER_CASES: ReadonlyArray<[string, string, boolean]> = [
+  // A malformed grant confers nothing — it must never be read as a shorter
+  // one it happens to start with.
+  ['rule:*:typo', 'rule:delete', false],
+  ['rule:*:typo', 'rule:write:structural', false],
+  ['rule:write:structural:extra', 'rule:write:structural', false],
+  ['metrics:read:typo', 'metrics:read', false],
+  ['*:read:typo', 'metrics:read', false],
+  // The documented grammar, unchanged.
+  ['rule:*', 'rule:delete', true],
+  ['rule:*', 'rule:write:structural', true],
+  ['rule:write:structural', 'rule:write:structural', true],
+  ['rule:write:structural', 'rule:write', false],
+  ['*:read', 'metrics:read', true],
+  ['metrics:*', 'metrics:read', true],
+  ['metrics:read', 'metrics:read', true],
+  // Wildcard-exempt: only a bare `*`, `admin`, or the verb itself.
+  ['*:read', 'audit:read', false],
+  ['audit:*', 'audit:read', false],
+  ['audit:read', 'audit:read', true],
+  ['*', 'audit:read', true],
+  ['admin', 'audit:read', true],
+];
+
+describe('the verb grammar, including what is NOT it', () => {
+  it.each(MATCHER_CASES)('%s grants %s → %s', (grant, required, expected) => {
+    expect(hasVerb([grant], required)).toBe(expected);
+  });
+
+  it('a malformed grant is reported at startup rather than quietly granting', () => {
+    // `split(':', 3)` truncates instead of failing, so `rule:*:typo` used to
+    // read as `rule:*` and hand over the whole area.
+    for (const g of ['rule:*:typo', 'rule:write:structural:extra', 'metrics:read:typo']) {
+      expect(isGrantRecognised(g), g).toBe(false);
+    }
   });
 });
 

--- a/apps/bff/src/rbac/verbs.ts
+++ b/apps/bff/src/rbac/verbs.ts
@@ -209,10 +209,17 @@ function matchOne(grant: Verb, required: Verb): boolean {
   if (grant === '*' || grant === 'admin') return true;
   if (grant === required) return true;
   if (WILDCARD_EXEMPT_VERBS.has(required)) return false;
+  // The grammar is at most three segments. `split(':', 3)` TRUNCATES rather
+  // than failing, so without this a fourth segment is silently dropped and
+  // `rule:write:structural:typo` grants `rule:write:structural` — a typo that
+  // confers authority instead of none.
+  if (grant.split(':').length > 3) return false;
   // `area:*` matches any verb in that area (and any sub-action — `rule:*` covers `rule:write:structural`)
   const [grantArea, grantAction, grantSub] = grant.split(':', 3);
   const [reqArea, reqAction, reqSub] = required.split(':', 3);
-  if (grantArea === reqArea && grantAction === '*') return true;
+  // `grantSub` must be absent: `rule:*:typo` is not a narrower `rule:*`, it is
+  // malformed, and reading it as the area wildcard grants the whole area.
+  if (grantArea === reqArea && grantAction === '*' && grantSub === undefined) return true;
   // `*:action` matches that action in any area
   if (grantArea === '*' && grantAction === reqAction && (grantSub ?? '') === (reqSub ?? '')) return true;
   // Sub-action exact match (e.g. grant `rule:write:structural` only matches itself)

--- a/apps/ui/src/features/admin/roles/RolesView.vue
+++ b/apps/ui/src/features/admin/roles/RolesView.vue
@@ -58,9 +58,12 @@ function hasVerb(grants: readonly string[], required: string): boolean {
     // this board draws a check mark for a grant the server denies, on the row
     // whose own hint says a wildcard does not include it.
     if (WILDCARD_EXEMPT_VERBS.has(required)) continue;
+    // Both as the BFF: a fourth segment is malformed rather than truncated,
+    // and `area:*` carries no sub-segment.
+    if (g.split(':').length > 3) continue;
     const gp = g.split(':', 3);
     const rp = required.split(':', 3);
-    if (gp[0] === rp[0] && gp[1] === '*') return true;
+    if (gp[0] === rp[0] && gp[1] === '*' && gp[2] === undefined) return true;
     if (gp[0] === '*' && gp[1] === rp[1] && (gp[2] ?? '') === (rp[2] ?? '')) return true;
     if (gp[0] === rp[0] && gp[1] === rp[1] && (gp[2] ?? '') === (rp[2] ?? '')) return true;
   }

--- a/apps/ui/src/state/auth.test.ts
+++ b/apps/ui/src/state/auth.test.ts
@@ -103,3 +103,40 @@ describe('auth store — no cached data survives an identity change', () => {
     expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
   });
 });
+
+/**
+ * The same table `apps/bff/src/rbac/verbs.test.ts` asserts, run through the
+ * UI's copy of the matcher. Three copies of it exist — this store, the Roles
+ * board, and the BFF — and they diverged together once: a malformed grant
+ * (`rule:*:typo`) read as the area wildcard on all three, so the sidebar
+ * offered pages the server would have allowed too. Pin them to one answer.
+ */
+const MATCHER_CASES: ReadonlyArray<[string, string, boolean]> = [
+  ['rule:*:typo', 'rule:delete', false],
+  ['rule:*:typo', 'rule:write:structural', false],
+  ['rule:write:structural:extra', 'rule:write:structural', false],
+  ['metrics:read:typo', 'metrics:read', false],
+  ['*:read:typo', 'metrics:read', false],
+  ['rule:*', 'rule:delete', true],
+  ['rule:*', 'rule:write:structural', true],
+  ['rule:write:structural', 'rule:write:structural', true],
+  ['rule:write:structural', 'rule:write', false],
+  ['*:read', 'metrics:read', true],
+  ['metrics:*', 'metrics:read', true],
+  ['metrics:read', 'metrics:read', true],
+  ['*:read', 'audit:read', false],
+  ['audit:*', 'audit:read', false],
+  ['audit:read', 'audit:read', true],
+  ['*', 'audit:read', true],
+  ['admin', 'audit:read', true],
+];
+
+describe('the auth store answers the verb grammar exactly as the BFF does', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it.each(MATCHER_CASES)('%s grants %s → %s', (grant, required, expected) => {
+    const auth = useAuthStore();
+    auth.user = { username: 'u', roles: ['r'], verbs: [grant] } as MeResponse;
+    expect(auth.hasVerb(required)).toBe(expected);
+  });
+});

--- a/apps/ui/src/state/auth.ts
+++ b/apps/ui/src/state/auth.ts
@@ -108,9 +108,12 @@ export const useAuthStore = defineStore('auth', () => {
       // BEFORE both wildcard branches, so `*:read` and `audit:*` are equally
       // denied.
       if (WILDCARD_EXEMPT_VERBS.has(verb)) continue;
+      // Both as the BFF: a fourth segment is malformed rather than truncated,
+      // and `area:*` carries no sub-segment.
+      if (g.split(':').length > 3) continue;
       const [ga, gact, gsub] = g.split(':', 3);
       const [ra, ract, rsub] = verb.split(':', 3);
-      if (ga === ra && gact === '*') return true;
+      if (ga === ra && gact === '*' && gsub === undefined) return true;
       if (ga === '*' && gact === ract && (gsub ?? '') === (rsub ?? '')) return true;
       if (ga === ra && gact === ract && (gsub ?? '') === (rsub ?? '')) return true;
     }

--- a/docs/access-control/rbac.md
+++ b/docs/access-control/rbac.md
@@ -102,7 +102,7 @@ A user's grant string is matched against a required verb using these rules:
 |---|---|
 | `*` or `admin` | Any verb. |
 | `area:verb` (exact) | The exact required verb (case-sensitive). |
-| `area:*` | Any verb in that area, including sub-actions: `rule:*` matches `rule:read`, `rule:write`, `rule:write:structural`, `rule:delete`. |
+| `area:*` | Any verb in that area, including sub-actions: `rule:*` matches `rule:read`, `rule:write`, `rule:write:structural`, `rule:delete`. The `*` is the whole second segment — `rule:*:anything` is not a narrower form of this, it is malformed, and grants nothing. |
 | `*:read` | The `read` action in any area: matches `metrics:read`, `alarms:read`, `cluster:read`, etc. Does **not** match `rule:write:structural` (the action is not `read`), and does **not** match `audit:read` — see below. |
 
 Effective verbs for a session are the **union** of all grants from all roles.

--- a/docs/changelog/1.1.0.md
+++ b/docs/changelog/1.1.0.md
@@ -19,6 +19,8 @@
 
 ### Fixes
 
+**A malformed permission no longer grants more than it says.** A grant is at most three segments, but a longer one used to be silently truncated to its first three — so `rule:*:typo` was read as `rule:*` and handed over every rule permission, and `rule:write:structural:extra` matched `rule:write:structural`. Anything outside the documented forms now matches nothing and is named in the startup warning alongside other unrecognised grants.
+
 **The BanyanDB audit configuration is only what a deployment actually differs on** — where the server is, how to authenticate to it, a namespace prefix, and how long to keep records. The groups' layout is bundled rather than exposed: one shard, which a sign-in rate never outgrows. That is also the safe default, because BanyanDB fixes a group's shard count at creation and does not move data when it changes — a shard count edited after records exist would route new ones away from the old ones rather than resharding. Horizon now reports such a difference instead of applying it. Replication is left to you: Horizon sets no replica count, so a deployment that wants the audit log replicated can create the two groups with the count it wants and Horizon will keep them that way.
 
 **The login audit list pages the way every other SkyWalking list does.** It asks for a page number rather than carrying a position between requests, which is the arrangement OAP uses for traces, logs, alarms and events alike. The page still shows 50 rows at a time and still reports only whether more exist; paging is bounded at 500 pages deep, and a request past that is refused rather than quietly answered with something else.

--- a/docs/setup/rbac.md
+++ b/docs/setup/rbac.md
@@ -96,6 +96,8 @@ Grants are dot-namespaced strings. Four matching modes:
 | `area:*` | Matches any verb in that area: `rule:*` grants `rule:read`, `rule:write`, `rule:write:structural`, `rule:delete`. |
 | `*:read` | Matches the `read` action across any area. |
 
+Nothing else is a grant. A string outside these forms — a typo like `rule:*:typo`, or a fourth segment — matches no verb and confers nothing; Horizon names it in a startup warning so it does not sit in your config looking effective.
+
 A user's effective verbs are the **union** of all grants from all their roles.
 
 ## `landingByRole`


### PR DESCRIPTION
`matchOne` parsed grants with `split(':', 3)`, which **truncates** rather than failing. Two consequences, both widening access on a typo:

- **`rule:*:typo` granted all of `rule:*`.** The `area:*` branch never looked at the third segment, so the string was read as the area wildcard — handing over `rule:read`, `rule:write`, `rule:write:structural` and `rule:delete`.
- **`rule:write:structural:extra` matched `rule:write:structural`.** The fourth segment was silently dropped.

A permission outside the documented grammar now matches nothing. Because `isGrantRecognised` delegates to this matcher, such a grant is also named in the startup warning instead of sitting in a config looking effective.

## The same bug lived in three places

The matcher has three copies — the BFF, the auth store, and the Roles board — and all three were wrong in the same way, so nothing contradicted anything. Each is fixed, and they are now pinned to a shared table of grant → required → expected cases asserted on both sides (`apps/bff/src/rbac/verbs.test.ts` and `apps/ui/src/state/auth.test.ts`), covering the malformed forms, the documented grammar, and the wildcard-exempt `audit:read`.

## Validation

Booted against a live OAP with `viewer: ["rule:*:typo", "rule:write:structural:extra"]`:

- Startup warning names both grants.
- `GET /api/rule`, `GET /api/rule/status` and `POST /api/rule/delete` all return **403**. Before this change the first two were allowed and the delete was one `rule:delete` away.

`pnpm type-check`, `pnpm lint` and 2709 unit tests pass; license headers clean.

## Docs

Both grammar tables now say that nothing outside the four forms is a grant, and that the `*` in `area:*` is the whole second segment — `rule:*:anything` is malformed, not a narrower wildcard. Changelog entry under Fixes.
