### PR TITLE
ci: pin pnpm/action-setup to the ASF-approved commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10 — the commit on the ASF allow-list; a version tag is refused
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10 — the commit on the ASF allow-list; a version tag is refused
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10 — the commit on the ASF allow-list; a version tag is refused
       - uses: actions/setup-node@v4
         with:
           node-version: '24'


### PR DESCRIPTION
## Why

Since 2026-09-05 every pull request's **CI** and **E2E** workflow ends in `startup_failure` — no job runs — on every branch, including ones that do not touch the workflows (the last green run was a main push on 2026-09-03). The ASF GitHub Actions policy admits a third-party action only at an approved commit SHA, and `pnpm/action-setup` is on [`approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) at exactly one commit, while `ci.yaml` and `e2e.yaml` asked for the `v4` tag, which resolves to a different commit.

## What

The three `pnpm/action-setup@v4` references (two in `ci.yaml`, one in `e2e.yaml`) become `pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86`, the approved commit, with a comment saying why a tag is not used. That commit is the action's **v6.0.10** release, two majors past the `v4` we asked for; the workflows pass it no inputs, and it keeps reading the pnpm version from the root `package.json`'s `packageManager` field, so the installed pnpm is unchanged. The Docker actions in `publish-image.yaml` are already pinned this way; nothing else in the workflows is third-party.

## Validation

This PR's own CI and E2E runs are the test: they start only if the pin is accepted, and they install the workspace only if the action still honours `packageManager`.