### PR TITLE
fix(infra-3d): frame the populated tiers and follow the theme

### DIFF
--- a/apps/ui/src/features/infra-3d/CLAUDE.md
+++ b/apps/ui/src/features/infra-3d/CLAUDE.md
@@ -232,6 +232,8 @@ Implementation:
 
 ### Materials and color
 
+The scene's NEUTRALS (canvas clear colour, tier slab and rim, ghost box, cube edges, cluster frames, hierarchy lines) come from the theme tokens through `useScenePalette` — read at mount and re-applied on a theme change, since WebGL cannot read a CSS variable. Never put a literal dark colour back on one of those: the light theme is drawn from the same code. Layer colours and alarm reds are signals, not surfaces, and stay as they are.
+
 Every layer carries a **tint** (`ZoneTint`) — a category drawn from
 `tintForLayer()`. The tint resolves to a CSS custom property via
 `tintCssVar()`, which is read once into a Three `Color`. This keeps

--- a/apps/ui/src/features/infra-3d/Infra3DLayerPanel.vue
+++ b/apps/ui/src/features/infra-3d/Infra3DLayerPanel.vue
@@ -177,7 +177,7 @@ function totalServicesInTier(tierZones: ZonePlacement[]): number {
   max-height: calc(100% - 120px);
   display: flex;
   flex-direction: column;
-  background: rgba(15, 19, 26, 0.88);
+  background: color-mix(in srgb, var(--sw-bg-1) 88%, transparent);
   border: 1px solid var(--sw-line-2);
   border-radius: 8px;
   backdrop-filter: blur(6px);
@@ -246,7 +246,7 @@ function totalServicesInTier(tierZones: ZonePlacement[]): number {
 .tier-block:last-child { border-bottom: none; }
 .tier-block.hidden { opacity: 0.5; }
 .tier-item:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: color-mix(in srgb, var(--sw-fg-0) 4%, transparent);
   color: var(--sw-fg-0);
 }
 .layer-sublist { list-style: none; margin: 0; padding: 2px 0 6px; }
@@ -259,7 +259,7 @@ function totalServicesInTier(tierZones: ZonePlacement[]): number {
   font-size: 11px;
   color: var(--sw-fg-2);
 }
-.layer-row:hover { background: rgba(255, 255, 255, 0.04); color: var(--sw-fg-0); }
+.layer-row:hover { background: color-mix(in srgb, var(--sw-fg-0) 4%, transparent); color: var(--sw-fg-0); }
 .layer-row.is-group .lr-name { font-weight: 700; }
 .lr-dot { width: 7px; height: 7px; border-radius: 2px; flex: 0 0 7px; background: var(--sw-fg-3); }
 .lr-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -297,7 +297,7 @@ function totalServicesInTier(tierZones: ZonePlacement[]): number {
   margin-left: 2px;
 }
 .eye-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--sw-fg-0) 8%, transparent);
   color: var(--sw-fg-0);
 }
 </style>

--- a/apps/ui/src/features/infra-3d/Infra3DScene.vue
+++ b/apps/ui/src/features/infra-3d/Infra3DScene.vue
@@ -29,7 +29,7 @@
   per-plane layer geometry and intra-zone call edges only.
 -->
 <script setup lang="ts">
-import { computed, onUnmounted, ref, shallowRef, watch } from 'vue';
+import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { TresCanvas } from '@tresjs/core';
 import { OrbitControls, Html } from '@tresjs/cientos';
@@ -74,6 +74,8 @@ import {
   RIPPLE_PHASES,
   useSceneMaterials,
 } from './composables/useSceneMaterials';
+import { readScenePalette } from './composables/useScenePalette';
+import { useThemeStore } from '@/state/theme';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -133,7 +135,19 @@ const placement = computePlacement(graph, props.planeOrder, props.groups, props.
 
 // Shared geometries + materials (cache-and-dispose factory). `dispose()`
 // in onUnmounted frees every GL resource owned here.
-const mats = useSceneMaterials();
+// WebGL cannot read a CSS variable: the scene's neutrals come from the theme
+// tokens at mount, and are re-applied when the theme changes.
+const themeStore = useThemeStore();
+const palette = ref(readScenePalette());
+const mats = useSceneMaterials(palette.value);
+watch(
+  () => themeStore.active,
+  async () => {
+    await nextTick();
+    palette.value = readScenePalette();
+    mats.applyPalette(palette.value);
+  },
+);
 const {
   resolveLayerColor,
   zoneMaterial,
@@ -918,7 +932,7 @@ onUnmounted(() => {
     @pointerup="onHostPointerUp"
   >
     <TresCanvas
-      clear-color="#0a0d12"
+      :clear-color="palette.bg0"
       :antialias="true"
       power-preference="high-performance"
       :fps-limit="30"
@@ -1322,7 +1336,7 @@ onUnmounted(() => {
   position: relative;
   width: 100%;
   height: 100%;
-  background: #0a0d12;
+  background: var(--sw-bg-0);
 }
 /* Hover tooltip + zone label content lives inside cientos <Html>
    portals — declared in the non-scoped block below since the portal
@@ -1349,7 +1363,7 @@ onUnmounted(() => {
   align-items: baseline;
   gap: 3px;
   padding: 1px 5px;
-  background: rgba(11, 14, 19, 0.88);
+  background: color-mix(in srgb, var(--sw-bg-0) 88%, transparent);
   border: 1px solid;
   border-radius: 8px;
   font-size: 9.5px;
@@ -1385,13 +1399,13 @@ onUnmounted(() => {
    forcing layout. */
 .detail-card {
   width: 244px;
-  background: rgba(15, 19, 26, 0.97);
-  border: 1px solid rgba(249, 115, 22, 0.55);
+  background: color-mix(in srgb, var(--sw-bg-1) 97%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sw-accent) 55%, transparent);
   border-radius: 10px;
   box-shadow:
-    0 0 0 1px rgba(249, 115, 22, 0.15),
+    0 0 0 1px color-mix(in srgb, var(--sw-accent) 15%, transparent),
     0 12px 28px -10px rgba(0, 0, 0, 0.7),
-    0 0 18px -6px rgba(249, 115, 22, 0.35);
+    0 0 18px -6px color-mix(in srgb, var(--sw-accent) 35%, transparent);
   pointer-events: auto;
   display: flex;
   flex-direction: column;
@@ -1489,8 +1503,8 @@ onUnmounted(() => {
   gap: 6px;
   width: 100%;
   padding: 8px 12px;
-  background: linear-gradient(180deg, rgba(249, 115, 22, 0.18), rgba(249, 115, 22, 0.08));
-  border: 1px solid rgba(249, 115, 22, 0.55);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--sw-accent) 18%, transparent), color-mix(in srgb, var(--sw-accent) 8%, transparent));
+  border: 1px solid color-mix(in srgb, var(--sw-accent) 55%, transparent);
   border-radius: 6px;
   color: var(--sw-accent-2);
   font-size: 12px;
@@ -1500,9 +1514,9 @@ onUnmounted(() => {
   transition: background 160ms, border-color 160ms, color 160ms;
 }
 .detail-card .d-btn:hover {
-  background: linear-gradient(180deg, rgba(249, 115, 22, 0.32), rgba(249, 115, 22, 0.16));
-  border-color: rgba(249, 115, 22, 0.85);
-  color: #ffe6c8;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--sw-accent) 32%, transparent), color-mix(in srgb, var(--sw-accent) 16%, transparent));
+  border-color: color-mix(in srgb, var(--sw-accent) 85%, transparent);
+  color: var(--sw-fg-0);
 }
 .detail-card .d-btn-arrow {
   font-size: 11px;

--- a/apps/ui/src/features/infra-3d/Infra3DView.vue
+++ b/apps/ui/src/features/infra-3d/Infra3DView.vue
@@ -531,7 +531,7 @@ function onPanelZoneFocus(zoneKey: string): void {
   align-items: center;
   justify-content: space-between;
   padding: 6px 12px;
-  background: rgba(15, 19, 26, 0.7);
+  background: color-mix(in srgb, var(--sw-bg-1) 70%, transparent);
   border: 1px solid var(--sw-line);
   border-radius: 6px;
   backdrop-filter: blur(8px);
@@ -577,7 +577,7 @@ function onPanelZoneFocus(zoneKey: string): void {
   align-items: center;
   gap: 8px;
   padding: 5px 10px 5px 8px;
-  background: rgba(15, 19, 26, 0.72);
+  background: color-mix(in srgb, var(--sw-bg-1) 72%, transparent);
   border: 1px solid var(--sw-line);
   border-radius: 6px;
   text-decoration: none;
@@ -586,7 +586,7 @@ function onPanelZoneFocus(zoneKey: string): void {
   z-index: 70;
   transition: background 0.15s;
 }
-.sw-brand:hover { background: rgba(15, 19, 26, 0.88); }
+.sw-brand:hover { background: color-mix(in srgb, var(--sw-bg-1) 88%, transparent); }
 .sw-brand-logo {
   display: inline-flex;
   align-items: center;
@@ -651,7 +651,7 @@ function onPanelZoneFocus(zoneKey: string): void {
   flex-direction: column;
   gap: 6px;
   padding: 8px;
-  background: rgba(15, 19, 26, 0.88);
+  background: color-mix(in srgb, var(--sw-bg-1) 88%, transparent);
   border: 1px solid var(--sw-line-2);
   border-radius: 8px;
   backdrop-filter: blur(6px);
@@ -671,7 +671,7 @@ function onPanelZoneFocus(zoneKey: string): void {
   align-items: center;
   gap: 7px;
   padding: 7px 11px;
-  background: rgba(15, 19, 26, 0.88);
+  background: color-mix(in srgb, var(--sw-bg-1) 88%, transparent);
   border: 1px solid var(--sw-line-2);
   border-radius: 8px;
   backdrop-filter: blur(6px);
@@ -683,11 +683,11 @@ function onPanelZoneFocus(zoneKey: string): void {
   transition: border-color 0.15s, color 0.15s;
 }
 .beacon-toggle:hover { color: var(--sw-fg-0); border-color: var(--sw-line); }
-.beacon-toggle.is-on { border-color: #ef4444; color: #fca5a5; }
+.beacon-toggle.is-on { border-color: var(--sw-err); color: var(--sw-err); }
 .beacon-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sw-fg-3); }
 .beacon-toggle.is-on .beacon-dot {
-  background: #ef4444;
-  box-shadow: 0 0 8px 1px rgba(239, 68, 68, 0.8);
+  background: var(--sw-err);
+  box-shadow: 0 0 8px 1px color-mix(in srgb, var(--sw-err) 80%, transparent);
   animation: beacon-pulse 1.4s infinite ease-in-out;
 }
 @keyframes beacon-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }

--- a/apps/ui/src/features/infra-3d/Infra3DView.vue
+++ b/apps/ui/src/features/infra-3d/Infra3DView.vue
@@ -38,9 +38,14 @@ import {
   type ZonePlacement,
 } from './composables/useScenePlacement';
 import logoSw from '@/assets/icons/logo-sw.svg?raw';
+import { AVAILABLE_THEMES, useThemeStore } from '@/state/theme';
 import { useInfra3dConfig } from './composables/useInfra3dConfig';
 import { useInfra3dLoader } from './composables/useInfra3dLoader';
 
+// The shipped logo is white-fill; a light theme gets the blue one, as the topbar does.
+const themeStoreForLogo = useThemeStore();
+const logoSwBlue = logoSw.replace(/fill="#fff"/g, 'fill="#1368B3"');
+const isLightAppearance = computed(() => AVAILABLE_THEMES.find((t) => t.id === themeStoreForLogo.active)?.appearance === 'light');
 const { t } = useI18n({ useScope: 'global' });
 
 /** Imperative handle on the scene's camera-control methods. The
@@ -502,7 +507,7 @@ function onPanelZoneFocus(zoneKey: string): void {
            sub-path. router-link prepends the base and stays in-SPA. -->
       <router-link class="sw-brand" to="/" :title="t('Back to Horizon')">
         <!-- eslint-disable-next-line vue/no-v-html -- build-time `?raw` import of a bundled SVG constant; no runtime input reaches it, and scripts/check-security.mjs scans the ?raw set for active content -->
-        <span class="sw-brand-logo" v-html="logoSw" />
+        <span class="sw-brand-logo" v-html="isLightAppearance ? logoSwBlue : logoSw" />
         <span class="sw-brand-text">
           <span class="sw-brand-line1">Apache SkyWalking</span>
           <span class="sw-brand-line2">{{ t('Horizon · 3D Infra Map') }}</span>

--- a/apps/ui/src/features/infra-3d/PipelineTimeline.vue
+++ b/apps/ui/src/features/infra-3d/PipelineTimeline.vue
@@ -250,7 +250,7 @@ const openStageState = computed<ROStageState | null>(() => {
 .pl {
   display: flex;
   flex-direction: column;
-  background: rgba(15, 19, 26, 0.92);
+  background: color-mix(in srgb, var(--sw-bg-1) 92%, transparent);
   border-top: 1px solid var(--sw-line);
   backdrop-filter: blur(6px);
   /* Above the bottom-left brand mark (z 70) so the stage-detail drawer,
@@ -296,10 +296,10 @@ const openStageState = computed<ROStageState | null>(() => {
   text-overflow: ellipsis;
 }
 .step.s-idle    .step-icon { color: var(--sw-fg-3); }
-.step.s-running .step-icon { color: #fcc419; animation: pulse 1.2s infinite ease-in-out; }
-.step.s-ok      .step-icon { color: #4ade80; }
-.step.s-warn    .step-icon { color: #f0a04b; }
-.step.s-error   .step-icon { color: #f87171; }
+.step.s-running .step-icon { color: var(--sw-warn); animation: pulse 1.2s infinite ease-in-out; }
+.step.s-ok      .step-icon { color: var(--sw-ok); }
+.step.s-warn    .step-icon { color: var(--sw-warn); }
+.step.s-error   .step-icon { color: var(--sw-err); }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
 
 .spacer { flex: 1; }
@@ -314,7 +314,7 @@ const openStageState = computed<ROStageState | null>(() => {
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
-.next-refresh.running { color: #fcc419; }
+.next-refresh.running { color: var(--sw-warn); }
 .refresh {
   width: 28px;
   border: 1px solid var(--sw-line-2);
@@ -353,10 +353,10 @@ const openStageState = computed<ROStageState | null>(() => {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.drawer-status[data-status='ok']    { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
-.drawer-status[data-status='warn']  { background: rgba(240, 160, 75, 0.15); color: #f0a04b; }
-.drawer-status[data-status='error'] { background: rgba(248, 113, 113, 0.15); color: #f87171; }
-.drawer-status[data-status='running'] { background: rgba(252, 196, 25, 0.15); color: #fcc419; }
+.drawer-status[data-status='ok']    { background: color-mix(in srgb, var(--sw-ok) 15%, transparent); color: var(--sw-ok); }
+.drawer-status[data-status='warn']  { background: color-mix(in srgb, var(--sw-warn) 15%, transparent); color: var(--sw-warn); }
+.drawer-status[data-status='error'] { background: color-mix(in srgb, var(--sw-err) 15%, transparent); color: var(--sw-err); }
+.drawer-status[data-status='running'] { background: color-mix(in srgb, var(--sw-warn) 15%, transparent); color: var(--sw-warn); }
 .drawer-status[data-status='idle']   { background: var(--sw-bg-3); color: var(--sw-fg-3); }
 .drawer-x {
   margin-left: auto;
@@ -408,6 +408,6 @@ details summary { font-size: 10.5px; color: var(--sw-fg-3); cursor: pointer; mar
 .probes th { font-weight: 600; color: var(--sw-fg-3); }
 .probes tr[data-status='ok']     td { color: var(--sw-fg-1); }
 .probes tr[data-status='empty']  td { color: var(--sw-fg-3); }
-.probes tr[data-status='failed'] td { color: #f87171; }
+.probes tr[data-status='failed'] td { color: var(--sw-err); }
 .mono { font-family: var(--sw-mono-font, monospace); }
 </style>

--- a/apps/ui/src/features/infra-3d/composables/useSceneMaterials.ts
+++ b/apps/ui/src/features/infra-3d/composables/useSceneMaterials.ts
@@ -56,6 +56,7 @@ import {
 } from './useLayerIconTexture';
 import { colorForLayer } from './useInfra3dConfig';
 import { readTintColor, type ZoneTint } from './useScenePlacement';
+import { readScenePalette, type ScenePalette } from './useScenePalette';
 
 /** Resolve the per-layer icon glyph. Routed through the same helper
  *  the sidebar uses (`shell/icons.layerIcon`) so the two surfaces
@@ -169,6 +170,8 @@ export interface SceneMaterials {
   iconStampMaterial: (layerKey: string, tint: ZoneTint) => MeshBasicMaterial;
   groupStampMaterial: (icon: string, hex: string) => MeshBasicMaterial;
   clusterLabel: (text: string, hex: string) => { mat: MeshBasicMaterial; aspect: number };
+  /** Recolour the surface materials for another theme, in place. */
+  applyPalette: (palette: ScenePalette) => void;
   dispose: () => void;
 }
 
@@ -178,7 +181,7 @@ export interface SceneMaterials {
  * the Scene's `onUnmounted`. Per-batch geometries (tubes, cluster frames)
  * are owned by `useSceneEdges` / the Scene template, not here.
  */
-export function useSceneMaterials(): SceneMaterials {
+export function useSceneMaterials(palette: ScenePalette = readScenePalette()): SceneMaterials {
   const colorCache = new Map<string, Color>();
   function colorByHex(hex: string): Color {
     let c = colorCache.get(hex);
@@ -211,7 +214,7 @@ export function useSceneMaterials(): SceneMaterials {
   // Transparent slate glass tier slab; depthWrite off so cubes/zones
   // blend through cleanly. Backface culling off so the slab looks solid.
   const planeMaterial = new MeshBasicMaterial({
-    color: new Color('#151a23'),
+    color: new Color(palette.slab),
     transparent: true,
     opacity: 0.4,
     side: DoubleSide,
@@ -221,7 +224,7 @@ export function useSceneMaterials(): SceneMaterials {
     polygonOffsetUnits: 1,
   });
   const planeEdgeMaterial = new LineBasicMaterial({
-    color: new Color('#3a4658'),
+    color: new Color(palette.slabRim),
     transparent: true,
     opacity: 0.8,
   });
@@ -245,18 +248,18 @@ export function useSceneMaterials(): SceneMaterials {
   });
   const crossPacketMat = new MeshBasicMaterial({ color: new Color('#ffd9b0') });
   const hierarchyMat = new MeshBasicMaterial({
-    color: new Color('#8b95a3'),
+    color: new Color(palette.edge),
     transparent: true,
     opacity: 0.7,
   });
   const ghostMat = new MeshBasicMaterial({
-    color: new Color('#1b2433'),
+    color: new Color(palette.ghost),
     transparent: true,
     opacity: 0.5,
     depthWrite: false,
   });
   const cubeEdgeMat = new LineBasicMaterial({
-    color: new Color('#7d8ba3'),
+    color: new Color(palette.edge),
     transparent: true,
     opacity: 0.9,
   });
@@ -276,7 +279,7 @@ export function useSceneMaterials(): SceneMaterials {
     depthWrite: false,
   });
   const clusterFrameMat = new LineBasicMaterial({
-    color: new Color('#5a6b86'),
+    color: new Color(palette.frame),
     transparent: true,
     opacity: 0.85,
   });
@@ -398,6 +401,15 @@ export function useSceneMaterials(): SceneMaterials {
     return e;
   }
 
+  function applyPalette(next: ScenePalette): void {
+    planeMaterial.color.set(next.slab);
+    planeEdgeMaterial.color.set(next.slabRim);
+    ghostMat.color.set(next.ghost);
+    cubeEdgeMat.color.set(next.edge);
+    hierarchyMat.color.set(next.edge);
+    clusterFrameMat.color.set(next.frame);
+  }
+
   function dispose(): void {
     nodeGeometry.dispose();
     packetGeometry.dispose();
@@ -458,6 +470,7 @@ export function useSceneMaterials(): SceneMaterials {
     iconStampMaterial,
     groupStampMaterial,
     clusterLabel,
+    applyPalette,
     dispose,
   };
 }

--- a/apps/ui/src/features/infra-3d/composables/useScenePalette.test.ts
+++ b/apps/ui/src/features/infra-3d/composables/useScenePalette.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { readScenePalette } from './useScenePalette';
+
+afterEach(() => {
+  const root = document.documentElement;
+  for (const p of ['--sw-bg-0', '--sw-bg-2', '--sw-line-3', '--sw-bg-3', '--sw-fg-2', '--sw-fg-3']) root.style.removeProperty(p);
+  root.removeAttribute('data-appearance');
+});
+
+describe('readScenePalette', () => {
+  it('reads the scene neutrals from the theme tokens and the appearance from the root', () => {
+    const root = document.documentElement;
+    root.style.setProperty('--sw-bg-0', '#F7F7FA');
+    root.style.setProperty('--sw-bg-2', '#eef0f4');
+    root.style.setProperty('--sw-line-3', '#b8bfcc');
+    root.style.setProperty('--sw-fg-2', '#5f6878');
+    root.setAttribute('data-appearance', 'light');
+    const p = readScenePalette();
+    expect(p).toMatchObject({ appearance: 'light', bg0: '#f7f7fa', slab: '#eef0f4', slabRim: '#b8bfcc', edge: '#5f6878' });
+  });
+
+  it('keeps the dark default for a token that is missing or is not a hex colour', () => {
+    document.documentElement.style.setProperty('--sw-bg-0', 'rgba(0, 0, 0, 0.5)');
+    const p = readScenePalette();
+    expect(p.bg0).toBe('#0a0d12');
+    expect(p.frame).toBe('#5b6373');
+    expect(p.appearance).toBe('dark');
+    expect(readScenePalette(null).slab).toBe('#151a23');
+  });
+});

--- a/apps/ui/src/features/infra-3d/composables/useScenePalette.ts
+++ b/apps/ui/src/features/infra-3d/composables/useScenePalette.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The neutral colours of the 3D scene, read from the active theme's tokens.
+ *
+ * WebGL cannot read a CSS variable, so the scene's background and the
+ * materials that are "surface" rather than "signal" (the tier slab and its
+ * rim, the ghost box, cube edges, cluster frames, hierarchy lines) take
+ * their colour from `--sw-*` at mount and again when the theme changes.
+ * Layer colours and alarm reds are signals and stay as they are.
+ */
+export interface ScenePalette {
+  appearance: 'dark' | 'light';
+  /** The canvas clear colour — `--sw-bg-0`. */
+  bg0: string;
+  /** The tier slab — `--sw-bg-2`. */
+  slab: string;
+  /** The slab's rim — `--sw-line-3`. */
+  slabRim: string;
+  /** The ghost box of a hidden tier — `--sw-bg-3`. */
+  ghost: string;
+  /** Cube outlines and hierarchy lines — `--sw-fg-2`. */
+  edge: string;
+  /** Cluster frames — `--sw-fg-3`. */
+  frame: string;
+}
+
+/** The dark theme's values, for a document without the tokens (tests). */
+const DARK: ScenePalette = {
+  appearance: 'dark',
+  bg0: '#0a0d12',
+  slab: '#151a23',
+  slabRim: '#3a4456',
+  ghost: '#1c222d',
+  edge: '#818a9c',
+  frame: '#5b6373',
+};
+
+const TOKEN: Record<Exclude<keyof ScenePalette, 'appearance'>, string> = {
+  bg0: '--sw-bg-0',
+  slab: '--sw-bg-2',
+  slabRim: '--sw-line-3',
+  ghost: '--sw-bg-3',
+  edge: '--sw-fg-2',
+  frame: '--sw-fg-3',
+};
+
+/** Only a hex colour can be handed to three.js; a token that resolves to
+ *  anything else (or nothing) keeps the dark default. */
+function hexOf(v: string): string | null {
+  const s = v.trim();
+  return /^#[0-9a-fA-F]{6}$/.test(s) ? s.toLowerCase() : null;
+}
+
+export function readScenePalette(root: Element | null = typeof document === 'undefined' ? null : document.documentElement): ScenePalette {
+  if (!root) return { ...DARK };
+  const style = getComputedStyle(root);
+  const out: ScenePalette = { ...DARK };
+  for (const k of Object.keys(TOKEN) as Array<keyof typeof TOKEN>) {
+    const hex = hexOf(style.getPropertyValue(TOKEN[k]));
+    if (hex) out[k] = hex;
+  }
+  out.appearance = root.getAttribute('data-appearance') === 'light' ? 'light' : 'dark';
+  return out;
+}

--- a/apps/ui/src/features/infra-3d/composables/useScenePlacement.test.ts
+++ b/apps/ui/src/features/infra-3d/composables/useScenePlacement.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computePlacement } from './useScenePlacement';
+import type { SceneGraph, SceneLayer } from './useMapTopology';
+
+function layer(key: string, plane: string, n: number): SceneLayer {
+  return {
+    key,
+    name: key,
+    level: null,
+    group: null,
+    serviceCount: n,
+    color: null,
+    plane,
+    nodes: Array.from({ length: n }, (_, i) => ({
+      nodeId: `${key}:${i}`,
+      layerKey: key,
+      serviceId: `${key}-${i}`,
+      name: `${key}-${i}`,
+      shortName: `${key}-${i}`,
+      normal: true,
+    })),
+    callEdges: [],
+  } as unknown as SceneLayer;
+}
+
+function graph(layers: SceneLayer[]): SceneGraph {
+  return { layers, nodesByKey: new Map(), hierarchyEdges: [], crossLayerEdges: [] } as unknown as SceneGraph;
+}
+
+describe('computePlacement bounds — what the camera frames', () => {
+  it('frames only the tiers that hold a zone', () => {
+    // One populated tier out of four: the bounds are that plane alone, so the
+    // default camera looks at it instead of at a point between empty planes.
+    const p = computePlacement(graph([layer('AI_AGENT', 'middleware', 3)]));
+    const middleware = p.planes.find((pl) => pl.id === 'middleware')!;
+    expect(p.bounds.minY).toBe(middleware.y);
+    expect(p.bounds.maxY).toBe(middleware.y);
+    expect(p.bounds.maxX - p.bounds.minX).toBe(middleware.width);
+    expect(p.bounds.maxZ - p.bounds.minZ).toBe(middleware.depth);
+  });
+
+  it('spans the populated tiers when there are several, and every plane when none is', () => {
+    const two = computePlacement(graph([layer('GENERAL', 'apps', 4), layer('MYSQL', 'infra', 1)]));
+    const apps = two.planes.find((pl) => pl.id === 'apps')!;
+    const infra = two.planes.find((pl) => pl.id === 'infra')!;
+    expect(two.bounds.maxY).toBe(apps.y);
+    expect(two.bounds.minY).toBe(infra.y);
+    expect(two.bounds.maxX - two.bounds.minX).toBe(Math.max(apps.width, infra.width));
+    const none = computePlacement(graph([]));
+    expect(none.bounds.minY).toBe(Math.min(...none.planes.map((pl) => pl.y)));
+    expect(none.bounds.maxY).toBe(Math.max(...none.planes.map((pl) => pl.y)));
+  });
+});

--- a/apps/ui/src/features/infra-3d/composables/useScenePlacement.ts
+++ b/apps/ui/src/features/infra-3d/composables/useScenePlacement.ts
@@ -602,8 +602,7 @@ export function computePlacement(
   const planes: PlanePlacement[] = [];
   const zones: ZonePlacement[] = [];
   const nodes = new Map<string, NodePlacement>();
-  let maxPlaneW = 0;
-  let maxPlaneD = 0;
+  const populated: Array<{ y: number; width: number; depth: number }> = [];
 
   for (const spec of order) {
     const id = spec.id;
@@ -683,8 +682,7 @@ export function computePlacement(
     const planeW = Math.max(totalW + 4, 14);
     const planeD = maxD + 2;
     planes.push({ id, name: spec.label, y: planeY, width: planeW, depth: planeD });
-    maxPlaneW = Math.max(maxPlaneW, planeW);
-    maxPlaneD = Math.max(maxPlaneD, planeD);
+    if (ordered.length > 0) populated.push({ y: planeY, width: planeW, depth: planeD });
 
     let cursor = -totalW / 2;
     for (const u of ordered) {
@@ -718,10 +716,14 @@ export function computePlacement(
     }
   }
 
-  const minY = 0;
-  const maxY = (order.length - 1) * PLANE_VGAP;
-  const halfX = maxPlaneW / 2;
-  const halfZ = maxPlaneD / 2;
+  // The bounds frame what is there to see: the tiers that hold a zone, not
+  // the whole stack. A deployment with one populated tier otherwise had the
+  // camera aimed between empty planes, with its one slab at the top edge.
+  const framed = populated.length > 0 ? populated : planes.map((p) => ({ y: p.y, width: p.width, depth: p.depth }));
+  const minY = Math.min(...framed.map((p) => p.y));
+  const maxY = Math.max(...framed.map((p) => p.y));
+  const halfX = Math.max(...framed.map((p) => p.width)) / 2;
+  const halfZ = Math.max(...framed.map((p) => p.depth)) / 2;
   return {
     planes,
     zones,

--- a/docs/changelog/1.1.0.md
+++ b/docs/changelog/1.1.0.md
@@ -73,6 +73,10 @@
 
 ### Fixes
 
+The **3D Infra Map** follows the theme: its canvas, tier slabs, rims, cube edges, panels and cards took their colours from a fixed dark palette, so a light theme such as Daybreak showed dark panels with unreadable text. They now come from the theme tokens and change with the theme.
+
+The **3D Infra Map** opens framed on the tiers that hold services. A deployment with one populated tier had its slab at the top edge of the view, because the default pose aimed between empty planes; the default and **Reset** views now frame what is there.
+
 **An expansion on the API dependency graph could land in a graph you had left.** Nothing stopped you switching endpoints while one was loading, and the branch then arrived in whatever graph had replaced it. Expanding now shows its pending state and holds the endpoint picker and the other expand handles until it lands. An expansion started while an admin preview is open also resolves against the draft being previewed, rather than against the published template the rest of the graph is not showing.
 
 **A map that failed its FIRST read showed a loading line for ever.** With nothing cached to fall back on there was no way to tell a read still in progress from one that had already failed, so the graph sat on "Reading data…" indefinitely. It now says the read failed and offers Retry.


### PR DESCRIPTION
## Why

Two things were wrong with the 3D Infra Map on a deployment that is not the demo:

- With services on only one tier (a single `AI_AGENT` layer on the middleware tier, say), the map opened with its one populated slab at the top edge of the view and empty planes filling the rest. The placement bounds the camera frames spanned the whole four-tier stack and the widest plane, populated or not, so the default pose aimed at a point between empty planes.
- Under a light theme such as Daybreak the map showed dark panels, a dark canvas and dark slabs with the light theme's dark text on top, unreadable. Its canvas clear colour, the tier slab and rim, the ghost box, cube edges, cluster frames, hierarchy lines, the panels, the detail card, the beacon and the pipeline drawer were all literal dark colours.

## What

**Framing.** `computePlacement` derives its bounds from the planes that hold at least one zone, and from every plane only when none does. The default camera pose and **Reset** frame what is there to see; a full deployment is framed as before, since every tier is populated there.

**Theme.** WebGL cannot read a CSS variable, so a small palette (`useScenePalette`) is read from the `--sw-*` tokens at mount and re-applied on a theme change: the canvas clear colour and the six neutral materials are recoloured in place. The chrome's literal colours become tokens and `color-mix`. Layer colours and alarm reds are signals, not surfaces, and stay as they are. The brand logo turns blue on a light theme, as the topbar's does. The map's guide notes the rule so a literal dark colour does not come back.

Unit tests cover the framed bounds (one populated tier, two, none) and the palette read (tokens present, missing, not a hex colour).

## Validation

`pnpm -r type-check`, eslint, the UI unit suite (896); and the map opened in Chromium against a local OAP whose only services sit on one tier: default framing centred on that tier, and Daybreak, Horizon and Meridian each drawn in their own colours with readable chrome.