### PR TITLE
fix(live-debug): keep an active capture's start time out of the rule column

### DIFF
--- a/apps/ui/src/features/operate/live-debug/DebugHistoryView.vue
+++ b/apps/ui/src/features/operate/live-debug/DebugHistoryView.vue
@@ -452,8 +452,9 @@ function clearAll(): void {
 
 .dh__col--meta {
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 4px 10px;
 }
 
 .dh__col--actions {

--- a/docs/changelog/1.1.0.md
+++ b/docs/changelog/1.1.0.md
@@ -125,6 +125,8 @@ The **3D Infra Map** opens framed on the tiers that hold services. A deployment 
 
 **The retention chart hid data classes whose retention happened to match.** Classes sharing a figure were merged into a single *All records (5)* bar — which reads as a fact about the backend when it is only a fact about today's configuration, and left an operator unable to see what they could change. Every class now has its own row. *Others* is the one row named for a group rather than a data type: BanyanDB keeps alarms, events, sampled traces, top-N and every profiling record together in `records`, so they share one retention and no name for a single one of them would be true.
 
+**On the live debugger's Capture history page, an active session's start time ran into the rule name beside it.** The left column of an *Active* row carries the DSL badge, the LIVE marker and the start time, and had no room for all three, so the time overlapped the `catalog · file · rule` text of the same row. The time now sits under the badges.
+
 ## Query cold stage
 
 ### Features


### PR DESCRIPTION
## Why
On the live debugger's Capture history page, an *Active* row's left column holds the DSL badge, the LIVE marker and the start time. That column is a fixed-width grid track and the three together are wider than it. The time never wraps, so it ran into the `catalog · file · rule` text of the same row.

## What
The meta column wraps. On an active row the start time drops under the badges, which matches the two-line rule column beside it. Completed rows (badge + time) still fit on one line and are unchanged. The column keeps its width, so the Active and Completed sections stay aligned with each other.

Changelog entry under *Operating Horizon → Fixes*.

## Validation
- Type-check, UI and BFF build, lint, unit tests and license headers are green.
- Rendered check: drove the page in headless Chromium against the Vite dev server (local OAP behind the BFF), seeded one active and two completed entries into the browser's capture history, and measured the row. Before, the time's right edge crossed the rule column by 21px; after, it ends 79px short of it, and completed rows are unchanged.
- No new UI strings and no docs change.