### PR TITLE
fix(zipkin): honour the Query cold stage toggle on Zipkin traces, and read a trace's age in days

### DIFF
--- a/apps/bff/CLAUDE.md
+++ b/apps/bff/CLAUDE.md
@@ -108,7 +108,8 @@ it empties it. A Cold toggle would blank the alarm list and the entity pickers.
 
 | Sends `coldStage` | Never sends it |
 |---|---|
-| `trace.ts` — traces | `alarms.ts` — `/api/alarms`, `/api/alarms/count` |
+| `trace.ts` — traces, native and Zipkin alike | `alarms.ts` — `/api/alarms`, `/api/alarms/count` |
+| `zipkin.ts` — the Zipkin list and trace-by-id (`coldStage` is OAP's own addition to the Zipkin API, bounded by `endTs` + `lookback`) | |
 | `log.ts`, `browser-errors.ts` — logs | `instance.ts` — the instance picker |
 | `dashboard.ts`, `landing.ts`, `explore.ts` — metrics | `endpoint.ts` — the endpoint picker |
 | `mqe-exec.ts` — one metric expression, run from the template editor | |

--- a/apps/bff/src/client/zipkin.ts
+++ b/apps/bff/src/client/zipkin.ts
@@ -93,6 +93,19 @@ export interface ZipkinTracesQuery {
   /** Lookback in millis (defaults 30 min). */
   lookback?: number;
   limit?: number;
+  /** Read the BanyanDB cold stage instead of hot+warm — OAP's own addition to
+   *  the Zipkin API, honoured with `endTs`/`lookback`. */
+  coldStage?: boolean;
+}
+
+/** The window and stage a by-id lookup may carry. Any one of them makes OAP
+ *  build a duration, and the others then take OAP's defaults: `endTs` now,
+ *  `lookback` its configured day. With none of the three the lookup is
+ *  unbounded. */
+export interface ZipkinTraceWindow {
+  endTs?: number;
+  lookback?: number;
+  coldStage?: boolean;
 }
 
 const DEFAULT_LOOKBACK_MS = 30 * 60_000;
@@ -185,6 +198,7 @@ export async function zipkinFetchTraces(
   qs.set('endTs', String(endTs));
   qs.set('lookback', String(lookback));
   qs.set('limit', String(query.limit ?? 20));
+  if (query.coldStage) qs.set('coldStage', 'true');
   const path = `/api/v2/traces?${qs.toString()}`;
   const arr = await zipkinFetch<ZipkinSpan[][]>(opts, path);
   return arr
@@ -199,9 +213,21 @@ export async function zipkinFetchTraces(
 export async function zipkinFetchTraceById(
   opts: ZipkinClientOpts,
   traceId: string,
+  window?: ZipkinTraceWindow,
 ): Promise<ZipkinSpan[]> {
-  const path = `/api/v2/trace/${encodeURIComponent(traceId)}`;
+  const qs = zipkinWindowParams(window);
+  const path = `/api/v2/trace/${encodeURIComponent(traceId)}${qs ? `?${qs}` : ''}`;
   return zipkinFetch<ZipkinSpan[]>(opts, path);
+}
+
+/** The query string of a by-id window: empty when nothing is asked. */
+export function zipkinWindowParams(window: ZipkinTraceWindow | undefined): string {
+  if (!window) return '';
+  const qs = new URLSearchParams();
+  if (typeof window.endTs === 'number' && Number.isFinite(window.endTs)) qs.set('endTs', String(window.endTs));
+  if (typeof window.lookback === 'number' && Number.isFinite(window.lookback)) qs.set('lookback', String(window.lookback));
+  if (window.coldStage) qs.set('coldStage', 'true');
+  return qs.toString();
 }
 
 /** The Zipkin service universe (`localEndpoint.serviceName` of recent spans) —

--- a/apps/bff/src/http/query/explore.ts
+++ b/apps/bff/src/http/query/explore.ts
@@ -260,6 +260,7 @@ export function registerExploreRoutes(app: FastifyInstance, deps: ExploreRouteDe
             endTs,
             lookback,
             limit: overFetchSize(limit),
+            coldStage: !!req.coldStage,
           });
           const { rows, hasNext } = takeOverFetched(fetched, limit);
           zipkin = { source: 'zipkin', traces: rows, hasNext, reachable: true };

--- a/apps/bff/src/http/query/trace.ts
+++ b/apps/bff/src/http/query/trace.ts
@@ -381,14 +381,24 @@ export async function fetchZipkinList(
   opts: ZipkinClientOpts,
   body: TraceListBody,
   maxPageSize: number,
+  coldStage = false,
 ): Promise<ZipkinTraceListResponse> {
   const limit = clampPageSize(body.pageSize, 20, maxPageSize);
+  // The window the caller asked for, as Zipkin's `endTs` + `lookback`:
+  // explicit bounds first, else the rolling minutes. Epoch millis, so the
+  // OAP offset the native branch applies has no part here.
+  const explicit = typeof body.startMs === 'number' && typeof body.endMs === 'number' && body.endMs > body.startMs;
+  const window = explicit
+    ? { endTs: body.endMs as number, lookback: (body.endMs as number) - (body.startMs as number) }
+    : { endTs: Date.now(), lookback: (body.windowMinutes ?? DEFAULT_WINDOW_MIN) * 60_000 };
   try {
     const fetched = await zipkinFetchTraces(opts, {
       serviceName: body.service,
       minDuration: body.minTraceDuration,
       maxDuration: body.maxTraceDuration,
+      ...window,
       limit: overFetchSize(limit),
+      coldStage,
     });
     const { rows, hasNext } = takeOverFetched(fetched, limit);
     return { source: 'zipkin', traces: rows, hasNext, reachable: true };
@@ -444,7 +454,7 @@ export function registerTraceRoutes(app: FastifyInstance, deps: TraceRouteDeps):
           ? fetchNativeList(opts, body, !!req.coldStage, offset, maxPageSize)
           : Promise.resolve(undefined),
         wantZipkin
-          ? fetchZipkinList(buildZipkinOpts(deps.config.current, deps.fetch), body, maxPageSize)
+          ? fetchZipkinList(buildZipkinOpts(deps.config.current, deps.fetch), body, maxPageSize, !!req.coldStage)
           : Promise.resolve(undefined),
       ]);
 
@@ -531,9 +541,19 @@ export function registerTraceRoutes(app: FastifyInstance, deps: TraceRouteDeps):
           } satisfies TraceDetailResponse);
         }
       }
-      // Zipkin.
+      // Zipkin. The caller's approximate window becomes `endTs` + `lookback`,
+      // OAP's additions to the Zipkin API, and the Cold pill rides with it
+      // as on the native branch above. Zipkin options, not the GraphQL
+      // `opts`: the two type-check alike, and the wrong one asks the
+      // GraphQL port for a Zipkin path.
       try {
-        const spans = await zipkinFetchTraceById(opts, params.traceId);
+        const startMs = Number(q.startMs);
+        const endMs = Number(q.endMs);
+        const bounded = Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs;
+        const spans = await zipkinFetchTraceById(buildZipkinOpts(deps.config.current, deps.fetch), params.traceId, {
+          ...(bounded ? { endTs: endMs, lookback: endMs - startMs } : {}),
+          coldStage: !!req.coldStage,
+        });
         const detail: ZipkinTraceDetailResponse = {
           source: 'zipkin',
           traceId: params.traceId,

--- a/apps/bff/src/http/query/zipkin-cold-stage.test.ts
+++ b/apps/bff/src/http/query/zipkin-cold-stage.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Cold pill on the Zipkin path. OAP's Zipkin-compatible API takes
+ * `coldStage` as its own addition, bounded by `endTs` and `lookback`; every
+ * Zipkin read Horizon makes must carry the flag when the header is on and
+ * nothing of it when the header is off. Asserted on the wire the fake OAP
+ * records, for the two Zipkin routes and the two Zipkin branches of the
+ * trace routes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cookie from '@fastify/cookie';
+import type { FetchLike } from '@skywalking-horizon-ui/api-client';
+import { configSchema } from '../../config/schema.js';
+import type { ConfigSource } from '../../config/loader.js';
+import { SessionStore } from '../../user/sessions.js';
+import { makeRouteAuthHook } from '../../rbac/route-policy.js';
+import { registerColdStageHook } from '../../util/duration.js';
+import { serviceLayerCatalog } from '../../logic/services/service-layer-catalog.js';
+import { registerZipkinRoutes } from './zipkin.js';
+import { registerTraceRoutes } from './trace.js';
+import { registerExploreRoutes } from './explore.js';
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+/** A fake OAP that answers every Zipkin read empty and the time probe with
+ *  UTC, and keeps each Zipkin URL it was asked. */
+function fakeOap(): { fetch: FetchLike; urls: URL[] } {
+  const urls: URL[] = [];
+  const fetch: FetchLike = async (rawUrl, init) => {
+    const url = new URL(String(rawUrl));
+    if (url.pathname.includes('/api/v2/')) {
+      urls.push(url);
+      return json([]);
+    }
+    const body = JSON.parse(String(init?.body ?? '{}')) as { query?: string };
+    if ((body.query ?? '').includes('getTimeInfo')) return json({ data: { getTimeInfo: { timezone: '+0000', currentTimestamp: Date.now() } } });
+    if ((body.query ?? '').includes('hasQueryTracesV2Support')) return json({ data: { hasQueryTracesV2Support: false } });
+    return json({ data: {} });
+  };
+  return { fetch, urls };
+}
+
+function fakeConfig(): ConfigSource {
+  const cfg = configSchema.parse({});
+  return { current: cfg, current_: () => cfg, path: '', onChange: () => () => {}, close: async () => {} };
+}
+
+async function build(fetchImpl: FetchLike): Promise<{ app: FastifyInstance; sid: string }> {
+  const config = fakeConfig();
+  const sessions = new SessionStore({ ttlMinutes: 60 });
+  const app = Fastify();
+  await app.register(cookie);
+  registerColdStageHook(app);
+  app.addHook('onRoute', makeRouteAuthHook({ config, sessions }));
+  const deps = { config, sessions, fetch: fetchImpl, serviceLayer: serviceLayerCatalog({ config, fetch: fetchImpl }) };
+  registerZipkinRoutes(app, deps as unknown as Parameters<typeof registerZipkinRoutes>[1]);
+  registerTraceRoutes(app, deps as unknown as Parameters<typeof registerTraceRoutes>[1]);
+  registerExploreRoutes(app, deps as unknown as Parameters<typeof registerExploreRoutes>[1]);
+  await app.ready();
+  return { app, sid: sessions.create('op', ['admin']).sid };
+}
+
+async function call(cold: boolean, method: 'GET' | 'POST', url: string, payload?: Record<string, unknown>): Promise<URL[]> {
+  const oap = fakeOap();
+  const { app, sid } = await build(oap.fetch);
+  const res = await app.inject({
+    method,
+    url,
+    headers: { cookie: `horizon_sid=${sid}`, ...(cold ? { 'x-horizon-cold-stage': '1' } : {}), ...(payload ? { 'content-type': 'application/json' } : {}) },
+    ...(payload ? { payload } : {}),
+  });
+  expect(res.statusCode).toBe(200);
+  return oap.urls;
+}
+
+const params = (u: URL): Record<string, string> => Object.fromEntries(u.searchParams.entries());
+
+describe('the Cold pill on the Zipkin routes', () => {
+  it('sends coldStage on the Zipkin list only while the header is on', async () => {
+    const on = await call(true, 'GET', '/api/zipkin/traces?limit=5&lookback=3600000&endTs=1700000000000');
+    expect(on).toHaveLength(1);
+    expect(params(on[0]!)).toMatchObject({ coldStage: 'true', lookback: '3600000', endTs: '1700000000000' });
+    const off = await call(false, 'GET', '/api/zipkin/traces?limit=5');
+    expect(off[0]!.searchParams.has('coldStage')).toBe(false);
+  });
+
+  it('bounds a by-id lookup to the window it came from, and asks nothing when it has neither', async () => {
+    const on = await call(true, 'GET', '/api/zipkin/trace/abc123?endTs=1700000000000&lookback=86400000');
+    expect(on[0]!.pathname.endsWith('/api/v2/trace/abc123')).toBe(true);
+    expect(params(on[0]!)).toEqual({ endTs: '1700000000000', lookback: '86400000', coldStage: 'true' });
+    const coldNoWindow = await call(true, 'GET', '/api/zipkin/trace/abc123');
+    expect(params(coldNoWindow[0]!)).toEqual({ coldStage: 'true' });
+    const off = await call(false, 'GET', '/api/zipkin/trace/abc123');
+    expect(off[0]!.search).toBe('');
+  });
+});
+
+describe('the Cold pill on the trace routes’ Zipkin branches', () => {
+  it('sends coldStage and the requested window on the layer list when the source is Zipkin', async () => {
+    const on = await call(true, 'POST', '/api/layer/general/traces', { source: 'zipkin', pageSize: 5, startMs: 1700000000000, endMs: 1700432000000 });
+    const zipkin = on.filter((u) => u.pathname.endsWith('/api/v2/traces'));
+    expect(zipkin).toHaveLength(1);
+    expect(params(zipkin[0]!)).toMatchObject({ coldStage: 'true', endTs: '1700432000000', lookback: '432000000' });
+    const rolling = await call(false, 'POST', '/api/layer/general/traces', { source: 'zipkin', pageSize: 5, windowMinutes: 90 });
+    const p = params(rolling.find((u) => u.pathname.endsWith('/api/v2/traces'))!);
+    expect(p.coldStage).toBeUndefined();
+    expect(p.lookback).toBe(String(90 * 60_000));
+    expect(Number(p.endTs)).toBeGreaterThan(1700000000000);
+  });
+
+  it('turns the by-id window into endTs and lookback and rides the flag with it', async () => {
+    const on = await call(true, 'GET', '/api/trace/abc123?source=zipkin&startMs=1700000000000&endMs=1700003600000&step=HOUR');
+    expect(on[0]!.pathname.endsWith('/api/v2/trace/abc123')).toBe(true);
+    // The Zipkin base, not the GraphQL port: the two option objects type-check alike.
+    expect(on[0]!.origin + on[0]!.pathname).toBe('http://127.0.0.1:9412/zipkin/api/v2/trace/abc123');
+    expect(params(on[0]!)).toEqual({ endTs: '1700003600000', lookback: '3600000', coldStage: 'true' });
+    const off = await call(false, 'GET', '/api/trace/abc123?source=zipkin');
+    expect(off[0]!.search).toBe('');
+  });
+});
+
+describe('the Cold pill on the Explore page’s Zipkin list', () => {
+  it('sends coldStage with the window the page asked for, so its detail reads the same stage', async () => {
+    const body = { kind: 'trace', traceSource: 'zipkin', window: { startMs: 1700000000000, endMs: 1700432000000 }, pageSize: 5 };
+    const on = await call(true, 'POST', '/api/explore/query', body);
+    const zipkin = on.filter((u) => u.pathname.endsWith('/api/v2/traces'));
+    expect(zipkin).toHaveLength(1);
+    expect(params(zipkin[0]!)).toMatchObject({ coldStage: 'true', endTs: '1700432000000' });
+    const off = await call(false, 'POST', '/api/explore/query', body);
+    expect(off.find((u) => u.pathname.endsWith('/api/v2/traces'))!.searchParams.has('coldStage')).toBe(false);
+  });
+});
+

--- a/apps/bff/src/http/query/zipkin.ts
+++ b/apps/bff/src/http/query/zipkin.ts
@@ -52,6 +52,7 @@ import { requireAuth } from '../../user/middleware.js';
 import { basicAuthHeader } from '../../client/graphql.js';
 import { overFetchSize, takeOverFetched } from '../../logic/paging/read-page.js';
 import { wireFetch } from '../../client/wire-log.js';
+import { zipkinWindowParams } from '../../client/zipkin.js';
 
 export interface ZipkinRouteDeps extends AuthDeps {
   fetch?: FetchLike;
@@ -185,6 +186,9 @@ export function registerZipkinRoutes(app: FastifyInstance, deps: ZipkinRouteDeps
           // Zipkin has no offset — the over-fetch is the only has-more signal
           // available here, and it can never become a pager.
           limit: overFetchSize(limit),
+          // OAP's own addition to the Zipkin API: the Cold pill reaches this
+          // route as `req.coldStage` like every trace read.
+          coldStage: req.coldStage ? 'true' : undefined,
         },
       );
       // Zipkin's `/traces` returns `Array<Array<Span>>` — one inner array
@@ -222,11 +226,22 @@ export function registerZipkinRoutes(app: FastifyInstance, deps: ZipkinRouteDeps
       if (!traceId || !/^[0-9a-fA-F]+$/.test(traceId)) {
         return reply.code(400).send({ error: 'invalid_trace_id' });
       }
+      // The window the trace was listed in, when the caller has one. With
+      // the Cold pill on it matters: any of the three makes OAP bound the
+      // lookup, and a cold trace is by definition older than the default
+      // day it would otherwise use.
+      const q = req.query as { endTs?: string; lookback?: string };
+      const window = zipkinWindowParams({
+        endTs: q.endTs ? Number(q.endTs) : undefined,
+        lookback: q.lookback ? Number(q.lookback) : undefined,
+        coldStage: !!req.coldStage,
+      });
       try {
         const { status, body } = await zipkinFetch(
           deps.config.current,
           deps.fetch,
           `/api/v2/trace/${encodeURIComponent(traceId)}`,
+          Object.fromEntries(new URLSearchParams(window)),
         );
         const detail: ZipkinTraceDetailResponse = {
           source: 'zipkin',

--- a/apps/ui/src/api/scopes/zipkin.test.ts
+++ b/apps/ui/src/api/scopes/zipkin.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import '../client';
+import { ZipkinApi } from './zipkin';
+import type { BffClient } from '../client';
+
+function api(): { api: ZipkinApi; request: ReturnType<typeof vi.fn> } {
+  const request = vi.fn().mockResolvedValue({ source: 'zipkin', traceId: 'abc', spans: [], reachable: true });
+  const bff = { request } as unknown as BffClient;
+  return { api: new ZipkinApi(bff), request };
+}
+
+describe('bff.zipkin.trace', () => {
+  it('carries the window the trace was listed in, so a cold-stage lookup is bounded there', async () => {
+    const { api: a, request } = api();
+    await a.trace('abc', { endTs: 1700000000000, lookback: 86400000 });
+    expect(request).toHaveBeenCalledWith('GET', '/api/zipkin/trace/abc?endTs=1700000000000&lookback=86400000');
+  });
+
+  it('keeps an explicit zero lookback, which OAP would otherwise widen to its default', async () => {
+    const { api: a, request } = api();
+    await a.trace('abc', { endTs: 1700000000000, lookback: 0 });
+    expect(request).toHaveBeenCalledWith('GET', '/api/zipkin/trace/abc?endTs=1700000000000&lookback=0');
+  });
+
+  it('asks for nothing but the id when it has no window', async () => {
+    const { api: a, request } = api();
+    await a.trace('abc');
+    await a.trace('abc', { endTs: null, lookback: null });
+    expect(request).toHaveBeenNthCalledWith(1, 'GET', '/api/zipkin/trace/abc');
+    expect(request).toHaveBeenNthCalledWith(2, 'GET', '/api/zipkin/trace/abc');
+  });
+});

--- a/apps/ui/src/api/scopes/zipkin.ts
+++ b/apps/ui/src/api/scopes/zipkin.ts
@@ -54,10 +54,18 @@ export class ZipkinApi {
       `/api/zipkin/traces${qs ? '?' + qs : ''}`,
     );
   }
-  trace(traceId: string): Promise<ZipkinTraceDetailResponse> {
+  /** One trace by id. `window` is the list's `endTs` + `lookback` when the
+   *  caller has them: with the Cold pill on, OAP bounds the lookup to a window
+   *  and a cold trace is older than the default day. */
+  trace(traceId: string, window?: { endTs?: number | null; lookback?: number | null }): Promise<ZipkinTraceDetailResponse> {
+    const params = new URLSearchParams();
+    const given = (v: number | null | undefined): v is number => typeof v === 'number' && Number.isFinite(v) && v >= 0;
+    if (given(window?.endTs)) params.set('endTs', String(window!.endTs));
+    if (given(window?.lookback)) params.set('lookback', String(window!.lookback));
+    const qs = params.toString();
     return this.bff.request<ZipkinTraceDetailResponse>(
       'GET',
-      `/api/zipkin/trace/${encodeURIComponent(traceId)}`,
+      `/api/zipkin/trace/${encodeURIComponent(traceId)}${qs ? '?' + qs : ''}`,
     );
   }
   autocompleteKeys(): Promise<string[]> {

--- a/apps/ui/src/features/admin/auth-status/AuthStatusView.vue
+++ b/apps/ui/src/features/admin/auth-status/AuthStatusView.vue
@@ -17,6 +17,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { relativeAgo } from '@/utils/formatters';
 import { bff } from '@/api/client';
 import type { AuthStatus } from '@/api/scopes/admin-auth';
 
@@ -88,11 +89,7 @@ function fmtBytes(n: number | null): string {
   return `${(n / 1024).toFixed(1)} KB`;
 }
 function fmtAgo(ms: number | null): string {
-  if (!ms) return '—';
-  const diff = Math.round((Date.now() - ms) / 1000);
-  if (diff < 60) return t('{n}s ago', { n: diff });
-  if (diff < 3600) return t('{n}m ago', { n: Math.round(diff / 60) });
-  return t('{n}h ago', { n: Math.round(diff / 3600) });
+  return relativeAgo(ms, t);
 }
 </script>
 

--- a/apps/ui/src/features/operate/explore/ExploreView.vue
+++ b/apps/ui/src/features/operate/explore/ExploreView.vue
@@ -479,6 +479,16 @@ async function runQuery(): Promise<void> {
     running.value = false;
     return;
   }
+  // The window this run reads, kept for the Zipkin detail: a by-id lookup
+  // bounded where the list found the trace, which with the Cold pill on is
+  // what finds it at all.
+  if (zipkin) {
+    const w = req.window;
+    zipkinDetailWindow.value =
+      typeof w.startMs === 'number' && typeof w.endMs === 'number' && w.endMs > w.startMs
+        ? { endTs: w.endMs, lookback: w.endMs - w.startMs }
+        : { endTs: Date.now(), lookback: (w.windowMinutes ?? 30) * 60_000 };
+  }
   try {
     const res = await bffClient.explore.query(req);
     if (res.kind === 'trace' && res.traceSource === 'native') {
@@ -559,8 +569,12 @@ const sourceRef = ref<'native' | 'zipkin'>('native');
 // segment-id → queryTrace path; the zipkin detail is layer-less.
 const nativeDetailTraceId = computed<string | null>(() => (isZipkin.value ? null : selectedTraceId.value));
 const zipkinDetailTraceId = computed<string | null>(() => (isZipkin.value ? selectedTraceId.value : null));
+const zipkinDetailWindow = ref<{ endTs: number; lookback: number } | null>(null);
 const { nativeDetail, isFetching: detailFetching } = useTraceDetail(nativeDetailTraceId, sourceRef);
-const { spans: zipkinSpans, isFetching: zipkinDetailFetching } = useZipkinTrace(zipkinDetailTraceId);
+const { spans: zipkinSpans, isFetching: zipkinDetailFetching } = useZipkinTrace(zipkinDetailTraceId, undefined, {
+  endTs: computed(() => zipkinDetailWindow.value?.endTs ?? null),
+  lookback: computed(() => zipkinDetailWindow.value?.lookback ?? null),
+});
 const waterfallSpans = computed<NativeSpan[]>(() => embeddedSpans.value ?? nativeDetail.value?.spans ?? []);
 const detailLoading = computed(() => (isZipkin.value ? zipkinDetailFetching.value : detailFetching.value));
 

--- a/apps/ui/src/layer/traces/LayerZipkinTracesView.vue
+++ b/apps/ui/src/layer/traces/LayerZipkinTracesView.vue
@@ -212,7 +212,9 @@ function runQuery(): void {
     cEndTs.value = e;
     cLookback.value = e - s;
   } else {
-    cEndTs.value = null;
+    // Frozen at the run, not left as "now": a pasted id is looked up in
+    // the window the list was read with, and that window has an end.
+    cEndTs.value = Date.now();
     cLookback.value = lookbackMs.value;
   }
   cLimit.value = limit.value;
@@ -294,7 +296,7 @@ const selectedRowSpans = computed<ZipkinSpan[] | null>(() => {
 const fallbackTraceId = computed<string | null>(() =>
   selectedTraceId.value && !selectedRowSpans.value ? selectedTraceId.value : null,
 );
-const { spans: fetchedSpans, isLoading: fetchLoading } = useZipkinTrace(fallbackTraceId, replay);
+const { spans: fetchedSpans, isLoading: fetchLoading } = useZipkinTrace(fallbackTraceId, replay, { endTs: cEndTs, lookback: cLookback });
 const selectedSpans = computed<ZipkinSpan[]>(() => selectedRowSpans.value ?? fetchedSpans.value);
 const selectedLoading = computed<boolean>(() => Boolean(fallbackTraceId.value) && fetchLoading.value);
 
@@ -348,7 +350,9 @@ const maxTraceDuration = computed<number>(() => {
 });
 function openByInput(): void {
   const v = traceIdInput.value.trim();
-  if (v) openTrace(v);
+  // The pasted id is looked up in the tab's window, which is what finds it
+  // in the cold stage; nothing else says when the trace was.
+  if (v) openTrace(v, { endTs: cEndTs.value, lookback: cLookback.value });
 }
 
 // Picking dots / brushing a box narrows the list to the picked set; no extra

--- a/apps/ui/src/layer/traces/ZipkinTracePopout.vue
+++ b/apps/ui/src/layer/traces/ZipkinTracePopout.vue
@@ -37,9 +37,12 @@ const { t } = useI18n({ useScope: 'global' });
 import { useZipkinTracePopout } from '@/layer/traces/useZipkinTracePopout';
 import { useZipkinTrace } from '@/layer/traces/useZipkinTraces';
 
-const { openTraceId, closeTrace } = useZipkinTracePopout();
+const { openTraceId, openTraceWindow, closeTrace } = useZipkinTracePopout();
 const traceIdRef = computed(() => openTraceId.value);
-const { spans, isLoading, error } = useZipkinTrace(traceIdRef);
+const { spans, isLoading, error } = useZipkinTrace(traceIdRef, undefined, {
+  endTs: computed(() => openTraceWindow.value?.endTs ?? null),
+  lookback: computed(() => openTraceWindow.value?.lookback ?? null),
+});
 
 interface WaterfallRow {
   span: ZipkinSpan;

--- a/apps/ui/src/layer/traces/useZipkinTracePopout.test.ts
+++ b/apps/ui/src/layer/traces/useZipkinTracePopout.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { zipkinPopoutWindow } from './useZipkinTracePopout';
+
+describe('zipkinPopoutWindow', () => {
+  it('takes the list window the id was opened in', () => {
+    expect(zipkinPopoutWindow({ traceId: 'a', traceEnd: '1700000000000', traceLookback: '432000000' })).toEqual({ endTs: 1700000000000, lookback: 432000000 });
+  });
+
+  it('spans half a day either side of the moment a row gave, as the native popout does', () => {
+    expect(zipkinPopoutWindow({ traceId: 'a', traceAt: '1700000000000' })).toEqual({ endTs: 1700000000000 + 43_200_000, lookback: 86_400_000 });
+  });
+
+  it('gives nothing for a bare id or a broken hint: unbounded hot, and OAP’s default day when cold', () => {
+    expect(zipkinPopoutWindow({ traceId: 'a' })).toBeNull();
+    expect(zipkinPopoutWindow({ traceId: 'a', traceEnd: 'soon', traceLookback: '1' })).toBeNull();
+    expect(zipkinPopoutWindow({ traceId: 'a', traceEnd: '1700000000000' })).toBeNull();
+  });
+
+  it('keeps an explicit zero lookback rather than widening it to the default', () => {
+    expect(zipkinPopoutWindow({ traceId: 'a', traceEnd: '1700000000000', traceLookback: '0' })).toEqual({ endTs: 1700000000000, lookback: 0 });
+  });
+});

--- a/apps/ui/src/layer/traces/useZipkinTracePopout.ts
+++ b/apps/ui/src/layer/traces/useZipkinTracePopout.ts
@@ -39,6 +39,29 @@ export function useTraceSourceIsZipkin() {
   });
 }
 
+/** The window a popped-out Zipkin trace is looked up in, from the address:
+ *  the list's window when the id was opened from one (`traceEnd` +
+ *  `traceLookback`), else half a day either side of the moment a row gave
+ *  (`traceAt`, as the native popout does), else nothing. With nothing and
+ *  the Cold pill off, OAP looks the id up unbounded; with the pill on it
+ *  searches its default day, which a cold trace is older than — so the
+ *  window is what finds a cold trace at all. */
+export function zipkinPopoutWindow(query: Record<string, unknown>): { endTs: number; lookback: number } | null {
+  const num = (k: string): number | null => {
+    const v = query[k];
+    const n = typeof v === 'string' ? Number(v) : NaN;
+    return Number.isFinite(n) && n >= 0 ? n : null;
+  };
+  const end = num('traceEnd');
+  const lookback = num('traceLookback');
+  if (end !== null && lookback !== null) return { endTs: end, lookback };
+  const at = num('traceAt');
+  if (at !== null) return { endTs: at + HALF_DAY_MS, lookback: 2 * HALF_DAY_MS };
+  return null;
+}
+
+const HALF_DAY_MS = 12 * 60 * 60_000;
+
 export function useZipkinTracePopout() {
   const route = useRoute();
   const router = useRouter();
@@ -48,10 +71,24 @@ export function useZipkinTracePopout() {
     const v = route.query.traceId;
     return typeof v === 'string' && v.length > 0 && sourceIsZipkin.value ? v : null;
   });
+  const openTraceWindow = computed(() => (openTraceId.value ? zipkinPopoutWindow(route.query as Record<string, unknown>) : null));
 
-  function openTrace(id: string): void {
+  /** Open a trace; `window` is the list window it was pasted or picked
+   *  in, `at` the moment a row gave — either bounds the lookup. */
+  function openTrace(id: string, hint?: { endTs?: number | null; lookback?: number | null; at?: number | null }): void {
     if (!id) return;
-    void router.replace({ path: route.path, query: { ...route.query, traceId: id } });
+    const next: Record<string, string> = { ...(route.query as Record<string, string>), traceId: id };
+    delete next.traceAt;
+    delete next.traceEnd;
+    delete next.traceLookback;
+    const given = (v: number | null | undefined): v is number => typeof v === 'number' && Number.isFinite(v) && v >= 0;
+    if (given(hint?.lookback)) {
+      next.traceEnd = String(given(hint?.endTs) ? hint!.endTs : Date.now());
+      next.traceLookback = String(hint!.lookback);
+    } else if (given(hint?.at)) {
+      next.traceAt = String(hint!.at);
+    }
+    void router.replace({ path: route.path, query: next });
   }
 
   function closeTrace(): void {
@@ -59,8 +96,10 @@ export function useZipkinTracePopout() {
     const next = { ...route.query };
     delete next.traceId;
     delete next.traceAt;
+    delete next.traceEnd;
+    delete next.traceLookback;
     void router.replace({ path: route.path, query: next });
   }
 
-  return { openTraceId, openTrace, closeTrace };
+  return { openTraceId, openTraceWindow, openTrace, closeTrace };
 }

--- a/apps/ui/src/layer/traces/useZipkinTraces.ts
+++ b/apps/ui/src/layer/traces/useZipkinTraces.ts
@@ -120,10 +120,19 @@ export function useLayerZipkinTraces(params: ZipkinTracesParams) {
   };
 }
 
-export function useZipkinTrace(traceId: Ref<string | null>, replay?: Ref<boolean>) {
+export function useZipkinTrace(
+  traceId: Ref<string | null>,
+  replay?: Ref<boolean>,
+  /** The list's window, so a cold-stage lookup is bounded where the trace was found. */
+  window?: { endTs?: Ref<number | null>; lookback?: Ref<number | null> },
+) {
   const q = useQuery<ZipkinTraceDetailResponse>({
-    queryKey: ['zipkin-trace', traceId],
-    queryFn: () => bffClient.zipkin.trace(traceId.value!),
+    queryKey: ['zipkin-trace', traceId, window?.endTs ?? computed(() => null), window?.lookback ?? computed(() => null)],
+    queryFn: () =>
+      bffClient.zipkin.trace(traceId.value!, {
+        endTs: window?.endTs?.value ?? null,
+        lookback: window?.lookback?.value ?? null,
+      }),
     // Replay rows carry their spans inline, so the by-id fallback never fires.
     enabled: computed(() => Boolean(traceId.value) && !replay?.value),
     staleTime: 60_000,

--- a/apps/ui/src/render/widgets/TraceListPanel.vue
+++ b/apps/ui/src/render/widgets/TraceListPanel.vue
@@ -47,6 +47,7 @@
 -->
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { relativeAgo } from '@/utils/formatters';
 import type { NativeTraceListRow } from '@/api/client';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -75,12 +76,7 @@ function parseNativeStart(v: string): number {
   return Number.isFinite(ts) ? ts : 0;
 }
 function fmtRelativeAgo(ts: number | null | undefined): string {
-  if (!ts) return '—';
-  const ms = Date.now() - ts;
-  if (ms < 1000) return t('just now');
-  if (ms < 60_000) return t('{n}s ago', { n: Math.round(ms / 1000) });
-  if (ms < 3_600_000) return t('{n}m ago', { n: Math.round(ms / 60_000) });
-  return t('{n}h ago', { n: Math.round(ms / 3_600_000) });
+  return relativeAgo(ts, t);
 }
 /**
  * Trace-result bar colour. Red is reserved for actual error-status

--- a/apps/ui/src/render/widgets/ZipkinTraceDetailCard.vue
+++ b/apps/ui/src/render/widgets/ZipkinTraceDetailCard.vue
@@ -69,6 +69,11 @@ function copyShareableUrl(): void {
   // Tag the source so Trace inspect (one route, two sources) reopens it as
   // Zipkin rather than native — IDs alone can't disambiguate.
   url.searchParams.set('source', 'zipkin');
+  // And the trace's moment, so the link resolves with the Cold pill on: a
+  // by-id lookup without a window searches OAP's default day, and a cold
+  // trace is older than that.
+  const { t0 } = detailBounds.value;
+  if (Number.isFinite(t0) && t0 > 0) url.searchParams.set('traceAt', String(Math.floor(t0 / 1000)));
   navigator.clipboard?.writeText(url.toString()).catch(() => {});
 }
 

--- a/apps/ui/src/shell/ColdStageTrapBanner.vue
+++ b/apps/ui/src/shell/ColdStageTrapBanner.vue
@@ -58,18 +58,15 @@ const { data: ttl } = useTtl();
  *  a cold tier at all.
  *
  *  This is the cold scope, not the storage's class list — Horizon sends the
- *  flag for traces, logs and metrics and nowhere else. Two classes are
- *  therefore deliberately absent:
+ *  flag for traces, logs and metrics and nowhere else. One class is
+ *  therefore deliberately absent: `records.normal` — alarms, events,
+ *  profiling and the rest of the group stay hot by design, so a shallow
+ *  retention there would fire this banner (and deepen its advice) over data
+ *  no cold read ever asks for.
  *
- *  - `records.normal` — alarms, events, profiling and the rest of the group
- *    stay hot by design, so a shallow retention there would fire this banner
- *    (and deepen its advice) over data no cold read ever asks for.
- *  - `records.zipkinTrace` — the Zipkin query endpoint takes no stage
- *    parameter, so the Zipkin trace route sends none. See apache/skywalking
- *    issue #14045, which proposes one.
- *
- *  Browser error logs ARE here: that route reads them as logs and does send
- *  the flag. */
+ *  Zipkin traces ARE here: OAP's Zipkin API takes the stage as its own
+ *  `coldStage` addition and the Zipkin routes send it. So are browser error
+ *  logs, read as logs. */
 const classes = computed<Array<{ hot: number; hasCold: boolean }>>(() => {
   const hot = ttl.value?.stages?.hot;
   if (!hot) return [];
@@ -83,6 +80,7 @@ const classes = computed<Array<{ hot: number; hasCold: boolean }>>(() => {
     pick(hot.metrics.hour, cold?.metrics.hour),
     pick(hot.metrics.day, cold?.metrics.day),
     pick(hot.records.trace, cold?.records.trace),
+    pick(hot.records.zipkinTrace, cold?.records.zipkinTrace),
     pick(hot.records.log, cold?.records.log),
     pick(hot.records.browserErrorLog, cold?.records.browserErrorLog),
   ].filter((c): c is { hot: number; hasCold: boolean } => c !== null);

--- a/apps/ui/src/shell/coldStageTrapBanner.test.ts
+++ b/apps/ui/src/shell/coldStageTrapBanner.test.ts
@@ -111,7 +111,7 @@ it('warns on the shallowest class it actually reads, not the shallowest there is
   ttl.value = {
     stages: {
       hot: {
-        records: { normal: 1, trace: 30, log: 30, zipkinTrace: 1, browserErrorLog: 30 },
+        records: { normal: 1, trace: 30, log: 30, zipkinTrace: 30, browserErrorLog: 30 },
         metrics: { minute: 30, hour: 30, day: 30, metadata: 30 },
       },
       cold: {

--- a/apps/ui/src/utils/formatters.relativeAgo.test.ts
+++ b/apps/ui/src/utils/formatters.relativeAgo.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { relativeAgo } from './formatters';
+
+const t = (key: string, named?: Record<string, unknown>): string =>
+  key.replace(/\{(\w+)\}/g, (_, k: string) => String(named?.[k] ?? ''));
+const NOW = 1_800_000_000_000;
+const H = 3_600_000;
+
+describe('relativeAgo', () => {
+  it('reads days and hours past a day, never a pile of hours', () => {
+    expect(relativeAgo(NOW - 288 * H, t, NOW)).toBe('12d 0h ago');
+    expect(relativeAgo(NOW - 27 * H - 5 * 60_000, t, NOW)).toBe('1d 3h ago');
+  });
+
+  it('reads hours and minutes under a day, minutes under an hour, seconds under a minute', () => {
+    expect(relativeAgo(NOW - 5 * H - 20 * 60_000, t, NOW)).toBe('5h 20m ago');
+    expect(relativeAgo(NOW - 59 * 60_000, t, NOW)).toBe('59m ago');
+    expect(relativeAgo(NOW - 42_000, t, NOW)).toBe('42s ago');
+    expect(relativeAgo(NOW - 400, t, NOW)).toBe('just now');
+  });
+
+  it('draws a dash for no moment', () => {
+    expect(relativeAgo(null, t, NOW)).toBe('—');
+    expect(relativeAgo(0, t, NOW)).toBe('—');
+  });
+});

--- a/apps/ui/src/utils/formatters.ts
+++ b/apps/ui/src/utils/formatters.ts
@@ -130,3 +130,26 @@ export function fmtMetricAs(
   }
   return fmtMetric(v);
 }
+
+/**
+ * How long ago a moment was, in the largest two units that fit, so an age
+ * past a day reads as days and hours rather than as a pile of hours.
+ * `t` is the caller's translator: the four texts are catalog keys.
+ */
+export function relativeAgo(
+  ts: number | null | undefined,
+  t: (key: string, named?: Record<string, unknown>) => string,
+  now = Date.now(),
+): string {
+  if (!ts || !Number.isFinite(ts)) return '—';
+  const ms = now - ts;
+  if (ms < 1000) return t('just now');
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return t('{n}s ago', { n: s });
+  const m = Math.floor(s / 60);
+  if (m < 60) return t('{n}m ago', { n: m });
+  const h = Math.floor(m / 60);
+  if (h < 24) return t('{h}h {m}m ago', { h, m: m % 60 });
+  return t('{d}d {h}h ago', { d: Math.floor(h / 24), h: h % 24 });
+}
+

--- a/docs/changelog/1.1.0.md
+++ b/docs/changelog/1.1.0.md
@@ -146,6 +146,12 @@ The **3D Infra Map** opens framed on the tiers that hold services. A deployment 
 
 **On the live debugger's Capture history page, an active session's start time ran into the rule name beside it.** The left column of an *Active* row carries the DSL badge, the LIVE marker and the start time, and had no room for all three, so the time overlapped the `catalog · file · rule` text of the same row. The time now sits under the badges.
 
+## Traces, logs and events
+
+### Fixes
+
+**A trace's age reads as days and hours.** The trace list on the Traces tab, native and Zipkin, wrote an age past a day as a count of hours, `288h ago`; it now reads `12d 0h ago`, hours and minutes under a day, minutes under an hour. The **Auth status** admin page's time of the last LDAP probe reads the same way.
+
 ## Query cold stage
 
 ### Features
@@ -153,6 +159,8 @@ The **3D Infra Map** opens framed on the tiers that hold services. A deployment 
 **Cold is asked for only where cold data is kept.** Traces, logs and metrics are the classes a deployment is advised to age into cold storage, and they are now the only ones Horizon sends the flag for. Alarms, the instance and endpoint pickers, events and everything from profiling stay hot — they are small, and they are the first things you reach for during an incident, so a Cold toggle emptying them bought nothing. Those pages keep answering while Cold is on.
 
 ### Fixes
+
+**Zipkin traces ignored the Query cold stage toggle.** The Zipkin Traces tab and its trace detail read the hot stage whatever the topbar toggle said, and said nothing about it. Both now send the toggle to OAP with the query, so with it on a Zipkin search reads the cold stage like a native one; a detail opened from the list is looked up in the window the list was read with, since a cold trace is older than the day OAP would otherwise search.
 
 **The cold-stage warning told you to pick a window that does not exist.** On a deployment with no cold stage configured — the BanyanDB default — it still said "pick a window older than N days", which cannot work, and following it moved the range out of hot+warm so the warning hid itself: a blank page with the one sentence explaining it gone. It now says plainly that no cold stage is configured and stays up until you turn Cold off. Where cold IS configured, the suggested window is the one that clears the deepest class rather than the shallowest — it used to name the records boundary (3 days by default) while every metric widget needed 7, so following it brought traces back and left the metrics exactly as empty. Both the warning and its advice are now decided by the classes Horizon actually reads under Cold — traces, logs and metrics. Alarms, events and profiling retention no longer count: they are usually kept for the shortest time of anything, and reading them here hid the warning for exactly the windows an operator turning Cold on is most likely to be looking at.
 

--- a/docs/operate/data-retention.md
+++ b/docs/operate/data-retention.md
@@ -24,7 +24,7 @@ Retention is reported in two stages:
 
 On a BanyanDB backend, a **cold-stage** toggle appears in the topbar. Enabling it switches reads to cold-only, so recent windows go empty — pick an older time range when the toggle is on. `no cold stage` next to a value means the connected OAP has no cold storage stage for that data class.
 
-The toggle applies to **traces, logs and metrics**, which are the classes a deployment is advised to age into cold storage. Alarms, events, the instance and endpoint pickers and everything from profiling are always read hot: they are small, and they are the first things you reach for during an incident, so emptying them would buy nothing. Those pages keep answering while the toggle is on.
+The toggle applies to **traces, logs and metrics** (native and Zipkin traces alike), which are the classes a deployment is advised to age into cold storage. Alarms, events, the instance and endpoint pickers and everything from profiling are always read hot: they are small, and they are the first things you reach for during an incident, so emptying them would buy nothing. Those pages keep answering while the toggle is on.
 
 When the toggle is on and the time range still overlaps hot+warm, a warning says so and names a window that clears the boundary. The window it suggests is the deepest of the classes above, not the shallowest — clearing only the shallowest brings traces back and leaves every metric widget exactly as empty. Where the connected OAP has no cold stage at all, no window can work, and the warning says that instead of suggesting one.
 


### PR DESCRIPTION
## Why

The topbar's **Query cold stage** toggle is documented as applying to traces, and the UI sends it on every request. On the Zipkin path the BFF dropped it: the Zipkin Traces tab and its trace detail read the hot stage whatever the toggle said, and said nothing about it. OAP's Zipkin-compatible API has taken `coldStage`, `endTs` and `lookback` as its own additions for a while, so the gap was one route in Horizon.

## What

**BFF.** The Zipkin list and trace-by-id routes, the Zipkin branches of the trace routes and the Explore page's Zipkin list send `coldStage=true` while the toggle is on. The layer trace route's Zipkin branch also forwards the window the page asked for, which it used to drop for a thirty-minute default. A by-id lookup carries the window the trace was listed or pasted in as `endTs` and `lookback`: any of the three makes OAP bound the lookup, and a cold trace is by definition older than the day OAP searches by default. The trace route's Zipkin by-id branch also queried the GraphQL port, because the Zipkin and GraphQL option objects type-check alike; it asks the Zipkin base now. Both Zipkin routes take their place in the cold-scope table in `apps/bff/CLAUDE.md`.

**UI.** The Zipkin tab's detail fallback and its paste-an-id popout pass the tab's committed window through (frozen at the run, not read as *now* later), the Explore page's Zipkin detail is bounded by the window its list was read with, and the popout keeps the window in the address (`traceEnd` + `traceLookback`, or `traceAt` for half a day either side of a row's moment, as the native popout does). A trace detail's copied link carries the trace's moment, so a shared link to a cold trace still resolves with the toggle on. The cold-stage trap banner now counts the Zipkin trace class among the classes a cold read touches.

**Age.** The trace list wrote an age past a day as a count of hours, `288h ago`. One shared formatter now reads days and hours past a day, hours and minutes under a day, minutes, seconds, and the trace list and the Auth status admin page's last-LDAP-probe time use it.

Docs: the data-retention page says the toggle covers native and Zipkin traces alike; two changelog entries.

## Validation

- Unit: a BFF wire test asserts the outgoing Zipkin URL for the two routes, the two trace-route branches and the Explore list with the header on and off, the requested window on the layer list, and the Zipkin base for the by-id branch; UI tests for the by-id query string, the popout window, a zero lookback and the formatter. Every suite green: BFF 1,717, UI 939, api-client 167, conversation-view 63; type-check, root lint, license headers.
- Live against the public demo OAP, whose `zipkinTrace` group keeps eight days hot and thirty cold. Directly on OAP: the last hour lists five traces hot and none cold; a five-day window twelve days back lists none hot and five cold. Through the BFF's Zipkin, layer-trace and Explore routes with the header on and off: the same. In Chromium on the Istio layer's Zipkin tab: the twelve-day-old window shows *No Zipkin traces* with the toggle off and thirty traces with it on, the rows reading `12d 0h ago`; pasting a cold trace id opens the popout with *No spans returned* off and the span waterfall on, the window in the address.
- One review round by an independent model against the rule book; its two blocking findings (a copied cold-trace link lost its window; Explore's list and detail read different stages), four should-fix items and two nits are all applied.
