### PR TITLE
fix(conversation-view): put each edit side's copy button beside its own name

### DIFF
--- a/packages/conversation-view/src/styles.css
+++ b/packages/conversation-view/src/styles.css
@@ -324,7 +324,9 @@ select.acv-stream-btn { border: 1px solid var(--acv-line); background: var(--acv
 .acv-copy { margin-left: 8px; padding: 0 5px; border: 1px solid var(--acv-line); border-radius: 4px; background: transparent; color: var(--acv-faint); font-family: inherit; font-size: 9px; line-height: 1.5; cursor: pointer; opacity: 0.6; vertical-align: middle; }
 .acv-copy:hover, .acv-copy:focus-visible { opacity: 1; color: var(--acv-text); }
 .acv-copy.done { opacity: 1; color: var(--sw-ok); border-color: color-mix(in srgb, var(--sw-ok) 50%, transparent); }
-.acv-copy-side { display: inline; margin-left: 2px; }
+.acv-copy-side { display: inline; }
+.acv-copy-side .acv-field-key { margin-right: 0; }
+.acv-edit-arrow { margin: 0 14px; color: var(--acv-faint); }
 .acv-kicker .acv-copy, .acv-result-label .acv-copy { font-weight: 400; letter-spacing: normal; text-transform: none; vertical-align: baseline; }
 .acv-edit-diff { display: block; margin-top: 2px; border-top: 0; border-left: 2px solid var(--acv-line); white-space: pre-wrap; overflow-wrap: anywhere; }
 .acv-clip-note { display: block; margin-top: 4px; color: var(--acv-faint); font-size: 10px; font-style: italic; }

--- a/packages/conversation-view/src/view/structured.ts
+++ b/packages/conversation-view/src/view/structured.ts
@@ -258,9 +258,9 @@ export function drawStructured(st: Structured, s: Pick<ViewStrings, 'copy'>): st
   const inline = rest.filter((f) => !f.block);
   const blocks = rest.filter((f) => f.block);
   const side = (f: StructuredField): string =>
-    `<span class="acv-copy-src" hidden>${esc(f.value)}</span>${copyButton(s, `${s.copy} ${f.key}`)}`;
+    `<span class="acv-field acv-copy-side"><span class="acv-field-key">${esc(f.key)}</span><span class="acv-copy-src" hidden>${esc(f.value)}</span>${copyButton(s, `${s.copy} ${f.key}`)}</span>`;
   const diff = pair
-    ? `<span class="acv-field block"><span class="acv-field-key">${EDIT_PAIR.join(' → ')}</span>${pair.map((f) => `<span class="acv-field acv-copy-side">${side(f)}</span>`).join('')}<pre class="acv-diff acv-edit-diff">${lineDiff(pair[0].value, pair[1].value)
+    ? `<span class="acv-field block">${side(pair[0])}<span class="acv-edit-arrow">→</span>${side(pair[1])}<pre class="acv-diff acv-edit-diff">${lineDiff(pair[0].value, pair[1].value)
         .map((r) => `<div class="acv-diff-line ${r.kind}">${esc((r.kind === 'add' ? '+' : r.kind === 'del' ? '-' : ' ') + r.text)}</div>`)
         .join('')}</pre></span>`
     : '';

--- a/packages/conversation-view/test/render.test.ts
+++ b/packages/conversation-view/test/render.test.ts
@@ -412,6 +412,20 @@ describe('copying a whole result', () => {
     expect(written).toEqual(['build succeeded', 'build succeeded']);
   });
 
+  it('copies the side of an edit whose copy button was clicked', async () => {
+    const written: string[] = [];
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText: (t: string) => (written.push(t), Promise.resolve()) }, configurable: true });
+    const doc = JSON.parse(readFileSync(resolve('test/fixtures/workspace-changes.json'), 'utf8')) as AszViewDocument;
+    const { root, view } = mount(undefined, undefined, doc);
+    view.setState({ step: 'tool/s3-tool' });
+    const sides = root.querySelectorAll<HTMLButtonElement>('.acv-inspector-body .acv-copy-side [data-copy]');
+    expect(sides).toHaveLength(2);
+    sides[0]!.click();
+    sides[1]!.click();
+    await Promise.resolve();
+    expect(written).toEqual(['var timeout = 30', 'var timeoutSeconds = 30']);
+  });
+
   it('leaves a result drawn as fields to their own copy buttons', () => {
     const doc = structuredClone(fixture) as AszViewDocument;
     const walk = (n: unknown): void => {

--- a/packages/conversation-view/test/structured.test.ts
+++ b/packages/conversation-view/test/structured.test.ts
@@ -143,9 +143,21 @@ describe('copy buttons and the edit diff', () => {
     const text = new ConversationModel(changes).step('tool/s3-tool')!.text!;
     const html = drawStructured(structure(text)!, S);
     expect(html).toContain('<span class="acv-field-key">file_path</span>');
-    expect(html).toContain('<span class="acv-field-key">old_string → new_string</span>');
     expect(html).toContain('<div class="acv-diff-line del">-var timeout = 30</div>');
     expect(html).toContain('<div class="acv-diff-line add">+var timeoutSeconds = 30</div>');
-    expect(html).not.toContain('<span class="acv-field-key">new_string</span>');
+    expect(html.match(/acv-field-value|acv-field-text/g)).toHaveLength(1);
+  });
+
+  it("puts each side's copy button beside that side's name", () => {
+    const host = document.createElement('div');
+    host.innerHTML = drawStructured(structure(new ConversationModel(changes).step('tool/s3-tool')!.text!)!, S);
+    const sides = Array.from(host.querySelectorAll('.acv-copy-side'), (side) => [
+      side.querySelector('.acv-field-key')?.textContent,
+      side.querySelector('.acv-copy')?.getAttribute('title'),
+    ]);
+    expect(sides).toEqual([
+      ['old_string', 'copy old_string'],
+      ['new_string', 'copy new_string'],
+    ]);
   });
 });


### PR DESCRIPTION
## Why

On the AI conversation page, an `Edit` tool call's input drew its header as one `old_string → new_string` label followed by both copy buttons. The first button, which copies `old_string`, sat right next to `new_string`, so it read as the new side's button; only the hover tooltip told the two apart.

## What

- Each side of the edit is now its name followed by its own copy button, with the arrow between the two sides: `old_string [copy] → new_string [copy]`. The spacing keeps each name tight to its button and sets the arrow apart, so the first button no longer groups with the arrow. The transcript card and the inspector's Details tab draw the same markup.
- Tests: one pins each copy button to its own side's name; one clicks both buttons and asserts each copies its own side.

No changelog or docs change: these copy buttons came in with #156 and have not shipped in a release, and both the 1.1.0 notes and `docs/operate/ai-agent-conversations.md` already say a field's copy button sits beside its name, which the edit pair now does. The AI Sessionizer's viewer picks this up on its next renderer re-pin.

## Validation

- `pnpm -r run type-check`, the UI and BFF builds, `pnpm -r run lint`, `pnpm -r run test:unit` (conversation-view 65, ui 1026, bff 1756, api-client 172) and `pnpm license:check` all pass.
- Rendered the built bundle in Chromium with the package's `workspace-changes` fixture: the header lays out left to right as `old_string`, copy, →, `new_string`, copy, and clicking the two buttons put `var timeout = 30` and `var timeoutSeconds = 30` on the clipboard respectively.
- Not run against a live OAP: this is a renderer-only markup and CSS change with no query or wire change.
- No new UI strings.